### PR TITLE
embedding시 일부 표 데이터가 한 줄씩 끊어서 진행되는 부분 수정

### DIFF
--- a/rag/etl/step05_embed/03_embed_protocols.py
+++ b/rag/etl/step05_embed/03_embed_protocols.py
@@ -166,6 +166,30 @@ def process_csv_simple(csv_path: Path, keyword: str) -> None:
 
     print(f"[EMBED][Protocol.io][{keyword}] 🎉 모든 CSV 데이터 임베딩 및 삽입 완료!")
 
+def is_table_like_text(text: str, min_rows: int = 3, min_cols: int = 3) -> bool:
+    """
+    텍스트가 표(tabular) 형태인지 간단히 판별
+    - 여러 줄 존재
+    - 각 줄에 탭 또는 2칸 이상 공백으로 구분된 컬럼이 반복
+    """
+    lines = [line for line in text.splitlines() if line.strip()]
+    
+    if len(lines) < min_rows:
+        return False
+
+    col_counts = []
+    for line in lines:
+        # 탭 또는 2칸 이상 공백 기준 분리
+        if "\t" in line:
+            cols = line.split("\t")
+        else:
+            cols = [c for c in line.split("  ") if c.strip()]
+        col_counts.append(len(cols))
+
+    # 대부분의 줄이 일정 컬럼 수 이상이면 표로 간주
+    avg_cols = sum(col_counts) / len(col_counts)
+    return avg_cols >= min_cols
+
 
 def process_csv(csv_path: Path, keyword: str) -> None:
     """CSV 파일을 읽어서 임베딩 생성 및 DB 저장"""
@@ -194,9 +218,17 @@ def process_csv(csv_path: Path, keyword: str) -> None:
 
         # 섹션별로 분리하여 임베딩
         sections = split_sections(text)
-        
-        if not sections:
-            # 섹션 태그가 없으면 전체 텍스트를 임베딩
+
+        no_section_tags = (
+            sections["abstract"].strip() == "" and
+            sections["step_content"].strip() == "" and
+            sections["guidelines"].strip() == ""
+        )
+
+        table_like = is_table_like_text(text)
+
+        if no_section_tags or table_like:
+            # 섹션 태그가 없거나, 표 형태 데이터면 전체 텍스트 임베딩
             embedding = embed_text(text)
             insert_row(chunking_id, url, title, text, embedding)
             print(f"[EMBED][Protocol.io][{keyword}] ✓ {idx + 1}/{len(df)} 저장 완료 (전체 텍스트)")


### PR DESCRIPTION
해당 파일에서 "abstract", "step_content", "guidelines" 등 태그가 포함된 chunk에서 포함된 표 데이터에서 한 줄 씩 embedding되는 문제를 수정하였습니다. is_table_like_text라는 함수이고, process_csv함수에서 조건문을 수정하였습니다.

<사전 설정>
- python 3.12
- .env.example 복사 후 .env로 변경
- .env에서 다음 값 삽입 필요 => OPENAI_API_KEY, OPENAI_MODEL, CLIENT_ACCESS_TOKEN
- CLIENT_ACCESS_TOKEN => https://www.protocols.io 로그인 => https://www.protocols.io/developers 하단에 client access token복사

<실행 방법>
1. /rag/etl/step01_ingest/03_ingest_protocols.py
2. /rag/etl/step02_normalize/03_normalize_protocols.py
3. /rag/etl/step04_chunk/03_chunker_protocols.py
4. /rag/etl/step05_embed/03_embed_protocols.py => 명령어 "python -m rag.etl.step05_embed.03_embed_protocols"(root에서)실행

<확인>
/data/row/protocols => 날짜 디렉토리(예: 20251222)안에 api_data_XXX.csv형식의 데이터 확인
/data/processed/protocols => success디렉토리 확인
success디렉토리 => 디렉토리 "stage=chunked", "stage=cleaned"확인 후 각 csv확인
docker-compose.yml에 정의된 pgvector연결 속성에 따라 DB연결 후 테이블 ts_protocol_embedding 확인