### PR TITLE
Feature/sims proteinn alpha unified(rfdiffusion / mpnn / alphafold 모듈 분리)

### DIFF
--- a/sim_tools/unified/api_server.py
+++ b/sim_tools/unified/api_server.py
@@ -16,20 +16,29 @@ OUTPUTS_DIR = os.environ.get("OUTPUTS_DIR", f"{SCRIPT_DIR}/outputs")
 TORCH_VENV = os.environ.get("TORCH_VENV", "/opt/venv_torch")
 PYTHONPATH = os.environ.get("PYTHONPATH", "/app/RFdiffusion")
 
-# (선택) 간단한 보호장치
 API_KEY = os.environ.get("API_KEY")  # 설정 안 하면 인증 없이 동작
 
-app = FastAPI(title="RFdiffusion Runner API")
+app = FastAPI(title="Unified Runner API")
 
 
 # ---------------- Models ----------------
 class RunRequest(BaseModel):
     mode: Literal["backbone", "binder", "other"] = "backbone"
+
+    # ⚠️ 기존 호환을 위해 남겨두되, 실제 실행에서는 무시함
     name: Optional[str] = None
+
     contigs: str = Field(default="100")
     iterations: int = Field(default=1, ge=1, le=1000)
 
-    # ✅ (선택) API 요청에서 로그 업로드까지 하고 싶으면 true
+    # ✅ S3 경로 규칙에 필요한 값
+    experiment_id: str = Field(..., description="pipeline=EXPERIMENT_ID (queue에서 받은 값)")
+    step: Literal["rfdiffusion", "alphafold", "proteinMPNN"] = Field(
+        default="rfdiffusion",
+        description="step=TOOL_NAME"
+    )
+
+    # ✅ (선택) 로그 업로드
     s3_upload_logs: bool = Field(default=False)
 
 
@@ -101,12 +110,10 @@ def health():
         "torch_venv": TORCH_VENV,
         "pythonpath": PYTHONPATH,
 
-        # 기존(최종적으로 쓰이는 값)
         "s3_bucket": os.environ.get("S3_BUCKET", ""),
-        "s3_prefix": os.environ.get("S3_PREFIX", "rfdiffusion"),
+        "s3_base": os.environ.get("S3_BASE", "simulations"),
         "aws_region": os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "")),
 
-        # ✅ 추가: RunPod에 AWS_S3_*로 넣었을 때 디버깅 편하게 같이 노출
         "aws_s3_bucket": os.environ.get("AWS_S3_BUCKET", ""),
         "aws_s3_base_path": os.environ.get("AWS_S3_BASE_PATH", ""),
     }
@@ -117,18 +124,28 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     _auth_or_throw(x_api_key)
     _ensure_paths()
 
+    experiment_id = req.experiment_id.strip()
+    if not experiment_id:
+        raise HTTPException(status_code=400, detail="experiment_id is required")
+
+    # ✅ 팀장님 지시: pipeline(=experiment_id) 하나가 job 하나
+    name = experiment_id
+
+    # job_id는 추적/응답용으로만 유지 (파일/폴더에는 사용 안 함)
     job_id = uuid.uuid4().hex[:12]
-    name = req.name or f"job_{job_id}"
 
     log_path, pid_path = _job_paths(name)
 
-    # ✅ 여기서 main.py에 s3_upload_logs 옵션을 넘겨줄지 결정
+    # ✅ main.py에 experiment_id / step 전달
     args = [
         "run",
         "--mode", req.mode,
-        "--name", name,
+        "--name", name,                 # ✅ EXP_0001
         "--contigs", req.contigs,
         "--iterations", str(req.iterations),
+
+        "--experiment_id", experiment_id,
+        "--step", req.step,
     ]
     if req.s3_upload_logs:
         args.append("--s3_upload_logs")
@@ -139,13 +156,12 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     env["OUTPUTS_DIR"] = OUTPUTS_DIR
     env["SCRIPT_DIR"] = SCRIPT_DIR
 
-    # ✅ 중요: S3 관련 env를 자식 프로세스(run)에도 확실히 전달
+    # S3/AWS env 전달
     env["S3_BUCKET"] = os.environ.get("S3_BUCKET", "")
-    env["S3_PREFIX"] = os.environ.get("S3_PREFIX", "rfdiffusion")
+    env["S3_BASE"] = os.environ.get("S3_BASE", "simulations")
     env["AWS_REGION"] = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", ""))
     env["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION", env["AWS_REGION"])
 
-    # ✅ (디버깅/호환) AWS_S3_*도 그대로 전달해두면 run 쪽에서 확인하기 쉬움
     env["AWS_S3_BUCKET"] = os.environ.get("AWS_S3_BUCKET", "")
     env["AWS_S3_BASE_PATH"] = os.environ.get("AWS_S3_BASE_PATH", "")
 
@@ -163,7 +179,7 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     return RunResponse(
         ok=True,
         job_id=job_id,
-        name=name,
+        name=name,  # ✅ EXP_0001
         outputs_dir=OUTPUTS_DIR,
         cmd=["bash", OPS_SH, *args],
     )

--- a/sim_tools/unified/src/main.py
+++ b/sim_tools/unified/src/main.py
@@ -4,6 +4,7 @@ import sys
 import argparse
 import subprocess
 from pathlib import Path
+from datetime import datetime, timezone, timedelta
 
 
 def resolve_rfdiffusion_entry() -> str:
@@ -48,57 +49,53 @@ def pick_python() -> str:
 
 
 def _get_s3_bucket_default() -> str:
-    """
-    Priority:
-      1) S3_BUCKET
-      2) AWS_S3_BUCKET
-    """
     return (os.environ.get("S3_BUCKET") or os.environ.get("AWS_S3_BUCKET") or "").strip()
 
 
-def _get_s3_prefix_default() -> str:
-    """
-    Priority:
-      1) S3_PREFIX
-      2) AWS_S3_BASE_PATH
-      3) rfdiffusion
-    Normalize: strip leading/trailing slashes.
-    """
-    raw = os.environ.get("S3_PREFIX") or os.environ.get("AWS_S3_BASE_PATH") or "rfdiffusion"
-    return str(raw).strip().strip("/")
+def _get_s3_base_default() -> str:
+    return (os.environ.get("S3_BASE") or "simulations").strip().strip("/")
+
+
+def _kst_today() -> str:
+    kst = timezone(timedelta(hours=9))
+    return datetime.now(tz=kst).strftime("%Y-%m-%d")
+
+
+def build_s3_prefix(base: str, dt: str, experiment_id: str, step: str) -> str:
+    base = (base or "simulations").strip().strip("/")
+    dt = dt.strip()
+    experiment_id = experiment_id.strip()
+    step = step.strip()
+    return f"{base}/dt={dt}/pipeline={experiment_id}/step={step}"
 
 
 def parse_args():
     p = argparse.ArgumentParser()
 
     p.add_argument("--mode", default="backbone", choices=["backbone", "binder", "other"])
-    p.add_argument("--name", default="test_rfd")
-    p.add_argument(
-        "--contigs",
-        default="100",
-        help="RFdiffusion contig string, e.g. 100 or 'A1-100' or 'A1-50 0 A51-100'",
-    )
-    p.add_argument("--iterations", type=int, default=50, help="num designs")
-    p.add_argument("--cautious", action="store_true", help="Set inference.cautious=True (skip existing outputs)")
+
+    # ⚠️ 여전히 받을 수는 있지만 실제로는 experiment_id로 덮어씀 (호환용)
+    p.add_argument("--name", default="test_job")
+
+    p.add_argument("--contigs", default="100")
+    p.add_argument("--iterations", type=int, default=1)
+    p.add_argument("--cautious", action="store_true")
 
     p.add_argument("--rfdiffusion_entry", default=resolve_rfdiffusion_entry())
     p.add_argument("--outputs_dir", default=os.environ.get("OUTPUTS_DIR", "/outputs"))
-    p.add_argument("--models_dir", default=os.environ.get("MODELS_DIR", "/models"))
 
-    # ✅ S3 업로드 옵션 (S3_*가 없으면 AWS_S3_* fallback 지원)
-    p.add_argument(
-        "--s3_bucket",
-        default=_get_s3_bucket_default(),
-        help="If set, upload outputs to S3",
-    )
-    p.add_argument(
-        "--s3_prefix",
-        default=_get_s3_prefix_default(),
-        help="S3 key prefix (folder path). Default uses S3_PREFIX or AWS_S3_BASE_PATH or 'rfdiffusion'",
-    )
-    p.add_argument("--s3_upload_logs", action="store_true", help="Also upload job log if exists")
-    p.add_argument("--fail_on_s3_error", action="store_true", help="If upload fails, exit non-zero")
+    # ✅ 새 구조에 필요한 필드
+    p.add_argument("--experiment_id", required=True)
+    p.add_argument("--step", default="rfdiffusion", choices=["rfdiffusion", "alphafold", "proteinMPNN"])
+    p.add_argument("--dt", default=_kst_today())
 
+    # ✅ S3 업로드 옵션
+    p.add_argument("--s3_bucket", default=_get_s3_bucket_default())
+    p.add_argument("--s3_base", default=_get_s3_base_default())
+    p.add_argument("--s3_upload_logs", action="store_true")
+    p.add_argument("--fail_on_s3_error", action="store_true")
+
+    # (옵션) 이후 확장용: MPNN/AF 세부파라미터를 CLI로 받게 하고 싶으면 여기에 추가하면 됨
     return p.parse_args()
 
 
@@ -110,53 +107,113 @@ def run_cmd(cmd, env=None):
 def main():
     args = parse_args()
 
+    # ✅ 팀장님 지시: job name = experiment_id
+    args.name = args.experiment_id.strip()
+
     outputs_dir = Path(args.outputs_dir)
     outputs_dir.mkdir(parents=True, exist_ok=True)
 
+    # 공통 env
     env = os.environ.copy()
     env.setdefault("DGLBACKEND", "pytorch")
     env.setdefault("DGL_DISABLE_GRAPHBOLT", "1")
 
-    contig_str = str(args.contigs).strip()
-    contig_override = f"contigmap.contigs=[{contig_str!r}]"
+    # -----------------------
+    # 1) step 분기 실행
+    # -----------------------
+    step = args.step
 
-    py = pick_python()
+    if step == "rfdiffusion":
+        contig_str = str(args.contigs).strip()
+        contig_override = f"contigmap.contigs=[{contig_str!r}]"
 
-    cmd = [
-        py,
-        args.rfdiffusion_entry,
-        f"inference.output_prefix={outputs_dir / args.name}",
-        f"inference.num_designs={args.iterations}",
-        contig_override,
-    ]
+        py = pick_python()
+        cmd = [
+            py,
+            args.rfdiffusion_entry,
+            f"inference.output_prefix={outputs_dir / args.name}",
+            f"inference.num_designs={int(args.iterations)}",
+            contig_override,
+        ]
+        if args.cautious:
+            cmd.append("inference.cautious=True")
 
-    if args.cautious:
-        cmd.append("inference.cautious=True")
+        run_cmd(cmd, env=env)
 
-    # 1) RFdiffusion 실행
-    run_cmd(cmd, env=env)
+        produced = [
+            outputs_dir / f"{args.name}_0.pdb",
+            outputs_dir / f"{args.name}_0.trb",
+        ]
 
+    elif step == "proteinMPNN":
+        # iterations를 num_seqs로 매핑 (테스트하기 가장 편함)
+        from steps.proteinmpnn_step import MPNNStepConfig, run_mpnn_only
+
+        cfg = MPNNStepConfig(
+            experiment_id=args.experiment_id.strip(),
+            outputs_dir=outputs_dir,
+            contigs=str(args.contigs).strip(),
+            num_seqs=int(args.iterations),
+            mpnn_sampling_temp=0.1,
+            rm_aa="C",
+        )
+        result = run_mpnn_only(cfg)
+        print("[proteinMPNN] result:", result)
+
+        produced = [
+            outputs_dir / f"{args.name}_mpnn.fasta",
+            outputs_dir / f"{args.name}_mpnn_results.csv",
+        ]
+
+    elif step == "alphafold":
+        # iterations를 num_recycles로 매핑 (1이면 빠름)
+        from steps.alphafold_step import AlphaFoldStepConfig, run_alphafold_only
+
+        cfg = AlphaFoldStepConfig(
+            experiment_id=args.experiment_id.strip(),
+            outputs_dir=outputs_dir,
+            num_recycles=int(args.iterations),
+            use_multimer=False,
+            initial_guess=False,
+        )
+        result = run_alphafold_only(cfg)
+        print("[alphafold] result:", result)
+
+        produced = [
+            outputs_dir / f"{args.name}_af_best.pdb",
+            outputs_dir / f"{args.name}_af_results.csv",
+        ]
+
+    else:
+        raise SystemExit(f"Unknown step: {step}")
+
+    # -----------------------
     # 2) 생성물 확인
-    produced = [
-        outputs_dir / f"{args.name}_0.pdb",
-        outputs_dir / f"{args.name}_0.trb",
-    ]
-
-    print("[main.py] produced:")
-    for p in produced:
-        if p.exists():
-            print(" -", p, f"({p.stat().st_size} bytes)")
+    # -----------------------
+    print(f"[main.py] step={step} produced:")
+    for pth in produced:
+        if pth.exists():
+            print(" -", pth, f"({pth.stat().st_size} bytes)")
         else:
-            print(" -", p, "(missing)")
+            print(" -", pth, "(missing)")
 
-    # 3) (옵션) S3 업로드
+    # -----------------------
+    # 3) S3 업로드 (옵션)
+    # -----------------------
     bucket = (args.s3_bucket or "").strip()
     if not bucket:
         print("[s3] S3_BUCKET/AWS_S3_BUCKET not set; skip upload")
         return
 
-    prefix = (args.s3_prefix or "rfdiffusion").strip().strip("/")
-    print(f"[s3] bucket={bucket} prefix={prefix}")
+    prefix = build_s3_prefix(
+        base=args.s3_base,
+        dt=args.dt,
+        experiment_id=args.experiment_id,
+        step=args.step,
+    )
+
+    print(f"[s3] bucket={bucket}")
+    print(f"[s3] prefix={prefix}")
 
     try:
         from s3_uploader import upload_job_outputs
@@ -170,6 +227,7 @@ def main():
         uploaded = upload_job_outputs(
             outputs_dir=str(outputs_dir),
             job_name=args.name,
+            step=args.step,
             bucket=bucket,
             prefix=prefix,
             upload_logs=args.s3_upload_logs,

--- a/sim_tools/unified/src/s3_uploader.py
+++ b/sim_tools/unified/src/s3_uploader.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import boto3
+import zipfile
 
 
 def _region() -> str | None:
@@ -8,10 +9,6 @@ def _region() -> str | None:
 
 
 def upload_file_to_s3(local_path: str, bucket: str, key: str, content_type: str | None = None) -> str:
-    """
-    Upload a single file to S3 and return s3:// URL.
-    Requires AWS creds in env or shared config.
-    """
     s3 = boto3.client("s3", region_name=_region())
 
     extra_args = {}
@@ -26,40 +23,93 @@ def upload_file_to_s3(local_path: str, bucket: str, key: str, content_type: str 
     return f"s3://{bucket}/{key}"
 
 
+def _zip_dir(src_dir: Path, zip_path: Path) -> Path | None:
+    if not src_dir.exists() or not src_dir.is_dir():
+        return None
+
+    files = [p for p in src_dir.rglob("*") if p.is_file()]
+    if not files:
+        return None
+
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for f in files:
+            zf.write(f, arcname=str(f.relative_to(src_dir)))
+    return zip_path if zip_path.exists() and zip_path.stat().st_size > 0 else None
+
+
 def upload_job_outputs(
     outputs_dir: str,
     job_name: str,
+    step: str,
     bucket: str,
-    prefix: str = "rfdiffusion",
+    prefix: str,
     upload_logs: bool = False
 ) -> list[str]:
     """
-    Upload:
-      - {job_name}_0.pdb
-      - {job_name}_0.trb
-      - (optional) _logs/{job_name}.log
-    to:
-      s3://{bucket}/{prefix}/{job_name}/...
+    Upload to:
+      s3://{bucket}/{prefix}/(files...)
+
+    prefix 예:
+      simulations/dt=YYYY-MM-DD/pipeline=EXPERIMENT_ID/step=rfdiffusion
     """
     out = Path(outputs_dir)
-    candidates = [
-        out / f"{job_name}_0.pdb",
-        out / f"{job_name}_0.trb",
-    ]
+    step = (step or "").strip()
+
+    candidates: list[Path] = []
+
+    if step == "rfdiffusion":
+        candidates += [
+            out / f"{job_name}_0.pdb",
+            out / f"{job_name}_0.trb",
+        ]
+
+    elif step == "proteinMPNN":
+        candidates += [
+            out / f"{job_name}_mpnn.fasta",
+            out / f"{job_name}_mpnn_results.csv",
+        ]
+
+    elif step == "alphafold":
+        candidates += [
+            out / f"{job_name}_af_best.pdb",
+            out / f"{job_name}_af_results.csv",
+        ]
+        # all_pdb 폴더는 zip으로 올리기(있으면)
+        all_dir = out / f"{job_name}_af_all_pdb"
+        zip_path = out / f"{job_name}_af_all_pdb.zip"
+        z = _zip_dir(all_dir, zip_path)
+        if z is not None:
+            candidates.append(z)
+
+    else:
+        raise ValueError(f"Unknown step for upload: {step}")
 
     if upload_logs:
         candidates.append(out / "_logs" / f"{job_name}.log")
 
-    # ✅ prefix 정규화: 앞/뒤 '/' 제거해서 key 깨짐 방지
-    prefix = (prefix or "rfdiffusion").strip().strip("/")
+    prefix = (prefix or "").strip().strip("/")
+    if not prefix:
+        raise ValueError("prefix is required")
 
     uploaded: list[str] = []
     for p in candidates:
         if not p.exists() or p.stat().st_size <= 0:
             continue
 
-        key = f"{prefix}/{job_name}/{p.name}"
-        content_type = "chemical/x-pdb" if p.suffix == ".pdb" else "application/octet-stream"
+        key = f"{prefix}/{p.name}"
+
+        if p.suffix == ".pdb":
+            content_type = "chemical/x-pdb"
+        elif p.suffix in [".fasta", ".fa"]:
+            content_type = "text/plain"
+        elif p.suffix == ".csv":
+            content_type = "text/csv"
+        elif p.suffix == ".zip":
+            content_type = "application/zip"
+        else:
+            content_type = "application/octet-stream"
+
         uploaded.append(upload_file_to_s3(str(p), bucket, key, content_type=content_type))
 
     return uploaded

--- a/sim_tools/unified/src/steps/alphafold_step.py
+++ b/sim_tools/unified/src/steps/alphafold_step.py
@@ -1,0 +1,132 @@
+# /workspace/unified/src/steps/alphafold_step.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+
+from colabdesign.af import mk_af_model
+
+
+@dataclass
+class AlphaFoldStepConfig:
+    experiment_id: str
+    outputs_dir: Path
+    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑할 예정(기본 1)
+    use_multimer: bool = False
+    initial_guess: bool = False
+
+
+def _read_fasta_seqs(fasta_path: Path) -> List[str]:
+    if not fasta_path.exists():
+        raise FileNotFoundError(f"[alphafold] fasta not found: {fasta_path}")
+
+    seqs = []
+    buf = []
+    for line in fasta_path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith(">"):
+            if buf:
+                seqs.append("".join(buf))
+                buf = []
+            continue
+        buf.append(line)
+    if buf:
+        seqs.append("".join(buf))
+
+    # 아주 기본 정제
+    seqs = [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
+    return seqs
+
+
+def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
+    exp = cfg.experiment_id
+    out_dir = cfg.outputs_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    input_pdb = out_dir / f"{exp}_0.pdb"
+    if not input_pdb.exists():
+        raise FileNotFoundError(
+            f"[alphafold] input pdb not found: {input_pdb} "
+            f"(먼저 step=rfdiffusion을 같은 experiment_id로 실행해야 함)"
+        )
+
+    fasta_path = out_dir / f"{exp}_mpnn.fasta"
+    seqs = _read_fasta_seqs(fasta_path)
+    if not seqs:
+        raise RuntimeError(f"[alphafold] no sequences in fasta: {fasta_path}")
+
+    all_pdb_dir = out_dir / f"{exp}_af_all_pdb"
+    all_pdb_dir.mkdir(parents=True, exist_ok=True)
+
+    flags = {
+        "initial_guess": bool(cfg.initial_guess),
+        "best_metric": "rmsd",
+        "use_multimer": bool(cfg.use_multimer),
+        "model_names": ["model_1_multimer_v3" if cfg.use_multimer else "model_1_ptm"],
+    }
+
+    # 여기서는 가장 단순한 fixbb로 검증만 한다.
+    # (binder/partial/fixbb 프로토콜 분기는 필요하면 이후에 contigs 기반으로 확장 가능)
+    af_model = mk_af_model(protocol="fixbb", **flags)
+
+    # 입력 구조만 읽어서 “틀”을 잡고, 이후 seq만 바꿔가며 predict
+    af_model.prep_inputs(str(input_pdb), chain="A")
+
+    rows = []
+    best = {"idx": -1, "plddt": -1.0, "rmsd": 1e9, "path": None}
+
+    for i, seq in enumerate(seqs):
+        af_model.predict(seq=seq, num_recycles=int(cfg.num_recycles), verbose=False)
+
+        # aux log에서 대표 지표 추출
+        aux = af_model.aux.get("log", {})
+        plddt = float(aux.get("plddt", 0.0))
+        ptm = float(aux.get("ptm", 0.0)) if "ptm" in aux else None
+        pae = float(aux.get("pae", 0.0)) if "pae" in aux else None
+        rmsd = float(aux.get("rmsd", 0.0)) if "rmsd" in aux else None
+
+        pdb_path = all_pdb_dir / f"af_n{i}.pdb"
+        af_model.save_current_pdb(str(pdb_path))
+
+        rows.append(
+            {
+                "n": i,
+                "plddt": plddt,
+                "ptm": ptm,
+                "pae": pae,
+                "rmsd": rmsd,
+                "pdb": str(pdb_path),
+                "seq": seq,
+            }
+        )
+
+        # best 기준: plddt 우선, 동률이면 rmsd 작은 것
+        if (plddt > best["plddt"]) or (plddt == best["plddt"] and (rmsd or 1e9) < best["rmsd"]):
+            best = {"idx": i, "plddt": plddt, "rmsd": (rmsd or 1e9), "path": pdb_path}
+
+        # 내부 카운터 증가(원 코드 흐름과 비슷하게 유지)
+        af_model._k += 1
+
+    csv_path = out_dir / f"{exp}_af_results.csv"
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+
+    best_path = out_dir / f"{exp}_af_best.pdb"
+    if best["path"] is not None and Path(best["path"]).exists():
+        best_path.write_text(Path(best["path"]).read_text())
+
+    return {
+        "input_pdb": str(input_pdb),
+        "input_fasta": str(fasta_path),
+        "csv": str(csv_path),
+        "best_pdb": str(best_path),
+        "all_pdb_dir": str(all_pdb_dir),
+        "num_seqs": len(rows),
+        "best_idx": best["idx"],
+        "best_plddt": best["plddt"],
+        "best_rmsd": best["rmsd"],
+    }

--- a/sim_tools/unified/src/steps/alphafold_step.py
+++ b/sim_tools/unified/src/steps/alphafold_step.py
@@ -14,11 +14,9 @@ from colabdesign.af import mk_af_model
 class AlphaFoldStepConfig:
     experiment_id: str
     outputs_dir: Path
-    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑
+    num_recycles: int = 1
     use_multimer: bool = False
     initial_guess: bool = False
-    # ✅ AlphaFold params 위치 (env로 지정 가능)
-    alphafold_params_dir: str | None = None
 
 
 def _read_fasta_seqs(fasta_path: Path) -> List[str]:
@@ -40,75 +38,46 @@ def _read_fasta_seqs(fasta_path: Path) -> List[str]:
     if buf:
         seqs.append("".join(buf))
 
-    # 기본 정제
-    seqs = [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
-    return seqs
+    return [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
 
 
-def _resolve_af_params_dir(cfg: AlphaFoldStepConfig) -> Path:
-    # 1) cfg에 명시된 값
-    if cfg.alphafold_params_dir:
-        return Path(cfg.alphafold_params_dir)
+def _ensure_colabdesign_params_visible():
+    """
+    ColabDesign(af)에서 보통 ./params 아래의 params_model_*.npz 를 찾는 경우가 많아서,
+    실행 cwd(/workspace/unified) 기준으로 params 링크를 강제로 보장한다.
+    """
+    models_dir = Path(os.environ.get("MODELS_DIR", "/models"))
+    real_params_dir = Path(os.environ.get("AF_DIR", str(models_dir / "alphafold")))
 
-    # 2) env 우선순위: ALPHAFOLD_PARAMS_DIR -> AF_DIR -> MODELS_DIR/alphafold
-    env_dir = (
-        os.environ.get("ALPHAFOLD_PARAMS_DIR")
-        or os.environ.get("AF_DIR")
-        or ""
-    )
-    if env_dir.strip():
-        return Path(env_dir.strip())
-
-    models_dir = os.environ.get("MODELS_DIR", "/models")
-    return Path(models_dir) / "alphafold"
-
-
-def _assert_params_exist(params_dir: Path, use_multimer: bool):
-    # ColabDesign이 보통 찾는 파일들 (tar에서 풀린 파일명 기준)
-    required = []
-    if use_multimer:
-        required.append(params_dir / "params_model_1_multimer_v3.npz")
-    else:
-        required.append(params_dir / "params_model_1_ptm.npz")
-
-    missing = [str(p) for p in required if not p.exists()]
-    if missing:
-        # 디버깅 도움용: params_dir 내용 일부 보여주기
-        sample = sorted([p.name for p in params_dir.glob("params_model_*.npz")])[:10]
+    # 실제 params 존재 확인
+    need = real_params_dir / "params_model_1_ptm.npz"
+    if not need.exists():
+        sample = sorted([p.name for p in real_params_dir.glob("params_model_*.npz")])[:10]
         raise FileNotFoundError(
             "[alphafold] AlphaFold params not found.\n"
-            f" - params_dir={params_dir}\n"
-            f" - missing={missing}\n"
+            f" - expected: {need}\n"
+            f" - AF_DIR={real_params_dir}\n"
             f" - found_sample={sample}\n"
-            "Fix: ensure params are extracted into /models/alphafold (or set ALPHAFOLD_PARAMS_DIR/AF_DIR)."
         )
 
-
-def _mk_af_model_with_params(protocol: str, flags: dict, params_dir: Path):
-    """
-    ColabDesign 버전 차이 대비:
-    - mk_af_model이 data_dir/params_dir/weights_dir 등을 받을 수도 있음
-    - 못 받으면 모델 생성 후 속성(params_dir/data_dir 등)을 강제로 세팅
-    """
-    # 1) kwarg로 넘기기 (가능한 키를 순서대로 시도)
-    for key in ("params_dir", "data_dir", "weights_dir"):
-        try:
-            return mk_af_model(protocol=protocol, **flags, **{key: str(params_dir)})
-        except TypeError:
-            pass
-
-    # 2) kwarg가 전부 실패하면 생성 후 속성 세팅 시도
-    af_model = mk_af_model(protocol=protocol, **flags)
-
-    # 흔한 속성명들(버전별 상이)을 최대한 커버
-    for attr in ("params_dir", "data_dir", "weights_dir"):
-        if hasattr(af_model, attr):
-            try:
-                setattr(af_model, attr, str(params_dir))
-            except Exception:
-                pass
-
-    return af_model
+    # cwd 기준 ./params 만들기 (symlink)
+    cwd_params = Path.cwd() / "params"
+    try:
+        if cwd_params.is_symlink() or cwd_params.exists():
+            # 이미 있으면 그대로 둠 (다른 곳 가리키면 덮어씀)
+            cwd_params.unlink()
+        cwd_params.symlink_to(real_params_dir, target_is_directory=True)
+    except Exception:
+        # symlink 실패 환경 대비: 디렉토리 생성 + 파일 일부라도 복사하는 fallback(무겁긴 하지만)
+        cwd_params.mkdir(parents=True, exist_ok=True)
+        # 최소한 ptm/multimer 파일은 보장
+        for p in real_params_dir.glob("params_model_*.npz"):
+            dst = cwd_params / p.name
+            if not dst.exists():
+                try:
+                    dst.write_bytes(p.read_bytes())
+                except Exception:
+                    pass
 
 
 def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
@@ -128,9 +97,8 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     if not seqs:
         raise RuntimeError(f"[alphafold] no sequences in fasta: {fasta_path}")
 
-    # ✅ params dir 확정 + 존재 체크
-    params_dir = _resolve_af_params_dir(cfg)
-    _assert_params_exist(params_dir, use_multimer=bool(cfg.use_multimer))
+    # ✅ 핵심: ColabDesign이 params를 찾을 수 있게 ./params 보장
+    _ensure_colabdesign_params_visible()
 
     all_pdb_dir = out_dir / f"{exp}_af_all_pdb"
     all_pdb_dir.mkdir(parents=True, exist_ok=True)
@@ -144,10 +112,9 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
         "model_names": [model_name],
     }
 
-    # ✅ params_dir를 확실히 전달해서 mk_af_model이 모델 파라미터를 찾게 함
-    af_model = _mk_af_model_with_params(protocol="fixbb", flags=flags, params_dir=params_dir)
+    # ✅ params_dir 같은 kwarg 절대 금지 (너 로그에서 바로 죽는 거 확인됨)
+    af_model = mk_af_model(protocol="fixbb", **flags)
 
-    # 입력 구조만 읽어서 “틀” 잡기
     af_model.prep_inputs(str(input_pdb), chain="A")
 
     rows = []
@@ -166,21 +133,12 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
         af_model.save_current_pdb(str(pdb_path))
 
         rows.append(
-            {
-                "n": i,
-                "plddt": plddt,
-                "ptm": ptm,
-                "pae": pae,
-                "rmsd": rmsd,
-                "pdb": str(pdb_path),
-                "seq": seq,
-            }
+            {"n": i, "plddt": plddt, "ptm": ptm, "pae": pae, "rmsd": rmsd, "pdb": str(pdb_path), "seq": seq}
         )
 
         if (plddt > best["plddt"]) or (plddt == best["plddt"] and (rmsd or 1e9) < best["rmsd"]):
             best = {"idx": i, "plddt": plddt, "rmsd": (rmsd or 1e9), "path": pdb_path}
 
-        # ColabDesign 내부 카운터 증가(기존 흐름 유지)
         af_model._k += 1
 
     csv_path = out_dir / f"{exp}_af_results.csv"
@@ -193,7 +151,6 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     return {
         "input_pdb": str(input_pdb),
         "input_fasta": str(fasta_path),
-        "alphafold_params_dir": str(params_dir),
         "model_name": model_name,
         "csv": str(csv_path),
         "best_pdb": str(best_path),

--- a/sim_tools/unified/src/steps/alphafold_step.py
+++ b/sim_tools/unified/src/steps/alphafold_step.py
@@ -1,12 +1,12 @@
 # /workspace/unified/src/steps/alphafold_step.py
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
 
 import pandas as pd
-
 from colabdesign.af import mk_af_model
 
 
@@ -14,17 +14,19 @@ from colabdesign.af import mk_af_model
 class AlphaFoldStepConfig:
     experiment_id: str
     outputs_dir: Path
-    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑할 예정(기본 1)
+    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑
     use_multimer: bool = False
     initial_guess: bool = False
+    # ✅ AlphaFold params 위치 (env로 지정 가능)
+    alphafold_params_dir: str | None = None
 
 
 def _read_fasta_seqs(fasta_path: Path) -> List[str]:
     if not fasta_path.exists():
         raise FileNotFoundError(f"[alphafold] fasta not found: {fasta_path}")
 
-    seqs = []
-    buf = []
+    seqs: List[str] = []
+    buf: List[str] = []
     for line in fasta_path.read_text().splitlines():
         line = line.strip()
         if not line:
@@ -38,9 +40,75 @@ def _read_fasta_seqs(fasta_path: Path) -> List[str]:
     if buf:
         seqs.append("".join(buf))
 
-    # 아주 기본 정제
+    # 기본 정제
     seqs = [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
     return seqs
+
+
+def _resolve_af_params_dir(cfg: AlphaFoldStepConfig) -> Path:
+    # 1) cfg에 명시된 값
+    if cfg.alphafold_params_dir:
+        return Path(cfg.alphafold_params_dir)
+
+    # 2) env 우선순위: ALPHAFOLD_PARAMS_DIR -> AF_DIR -> MODELS_DIR/alphafold
+    env_dir = (
+        os.environ.get("ALPHAFOLD_PARAMS_DIR")
+        or os.environ.get("AF_DIR")
+        or ""
+    )
+    if env_dir.strip():
+        return Path(env_dir.strip())
+
+    models_dir = os.environ.get("MODELS_DIR", "/models")
+    return Path(models_dir) / "alphafold"
+
+
+def _assert_params_exist(params_dir: Path, use_multimer: bool):
+    # ColabDesign이 보통 찾는 파일들 (tar에서 풀린 파일명 기준)
+    required = []
+    if use_multimer:
+        required.append(params_dir / "params_model_1_multimer_v3.npz")
+    else:
+        required.append(params_dir / "params_model_1_ptm.npz")
+
+    missing = [str(p) for p in required if not p.exists()]
+    if missing:
+        # 디버깅 도움용: params_dir 내용 일부 보여주기
+        sample = sorted([p.name for p in params_dir.glob("params_model_*.npz")])[:10]
+        raise FileNotFoundError(
+            "[alphafold] AlphaFold params not found.\n"
+            f" - params_dir={params_dir}\n"
+            f" - missing={missing}\n"
+            f" - found_sample={sample}\n"
+            "Fix: ensure params are extracted into /models/alphafold (or set ALPHAFOLD_PARAMS_DIR/AF_DIR)."
+        )
+
+
+def _mk_af_model_with_params(protocol: str, flags: dict, params_dir: Path):
+    """
+    ColabDesign 버전 차이 대비:
+    - mk_af_model이 data_dir/params_dir/weights_dir 등을 받을 수도 있음
+    - 못 받으면 모델 생성 후 속성(params_dir/data_dir 등)을 강제로 세팅
+    """
+    # 1) kwarg로 넘기기 (가능한 키를 순서대로 시도)
+    for key in ("params_dir", "data_dir", "weights_dir"):
+        try:
+            return mk_af_model(protocol=protocol, **flags, **{key: str(params_dir)})
+        except TypeError:
+            pass
+
+    # 2) kwarg가 전부 실패하면 생성 후 속성 세팅 시도
+    af_model = mk_af_model(protocol=protocol, **flags)
+
+    # 흔한 속성명들(버전별 상이)을 최대한 커버
+    for attr in ("params_dir", "data_dir", "weights_dir"):
+        if hasattr(af_model, attr):
+            try:
+                setattr(af_model, attr, str(params_dir))
+            except Exception:
+                pass
+
+    return af_model
 
 
 def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
@@ -60,21 +128,26 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     if not seqs:
         raise RuntimeError(f"[alphafold] no sequences in fasta: {fasta_path}")
 
+    # ✅ params dir 확정 + 존재 체크
+    params_dir = _resolve_af_params_dir(cfg)
+    _assert_params_exist(params_dir, use_multimer=bool(cfg.use_multimer))
+
     all_pdb_dir = out_dir / f"{exp}_af_all_pdb"
     all_pdb_dir.mkdir(parents=True, exist_ok=True)
+
+    model_name = "model_1_multimer_v3" if cfg.use_multimer else "model_1_ptm"
 
     flags = {
         "initial_guess": bool(cfg.initial_guess),
         "best_metric": "rmsd",
         "use_multimer": bool(cfg.use_multimer),
-        "model_names": ["model_1_multimer_v3" if cfg.use_multimer else "model_1_ptm"],
+        "model_names": [model_name],
     }
 
-    # 여기서는 가장 단순한 fixbb로 검증만 한다.
-    # (binder/partial/fixbb 프로토콜 분기는 필요하면 이후에 contigs 기반으로 확장 가능)
-    af_model = mk_af_model(protocol="fixbb", **flags)
+    # ✅ params_dir를 확실히 전달해서 mk_af_model이 모델 파라미터를 찾게 함
+    af_model = _mk_af_model_with_params(protocol="fixbb", flags=flags, params_dir=params_dir)
 
-    # 입력 구조만 읽어서 “틀”을 잡고, 이후 seq만 바꿔가며 predict
+    # 입력 구조만 읽어서 “틀” 잡기
     af_model.prep_inputs(str(input_pdb), chain="A")
 
     rows = []
@@ -83,7 +156,6 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     for i, seq in enumerate(seqs):
         af_model.predict(seq=seq, num_recycles=int(cfg.num_recycles), verbose=False)
 
-        # aux log에서 대표 지표 추출
         aux = af_model.aux.get("log", {})
         plddt = float(aux.get("plddt", 0.0))
         ptm = float(aux.get("ptm", 0.0)) if "ptm" in aux else None
@@ -105,11 +177,10 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
             }
         )
 
-        # best 기준: plddt 우선, 동률이면 rmsd 작은 것
         if (plddt > best["plddt"]) or (plddt == best["plddt"] and (rmsd or 1e9) < best["rmsd"]):
             best = {"idx": i, "plddt": plddt, "rmsd": (rmsd or 1e9), "path": pdb_path}
 
-        # 내부 카운터 증가(원 코드 흐름과 비슷하게 유지)
+        # ColabDesign 내부 카운터 증가(기존 흐름 유지)
         af_model._k += 1
 
     csv_path = out_dir / f"{exp}_af_results.csv"
@@ -122,6 +193,8 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     return {
         "input_pdb": str(input_pdb),
         "input_fasta": str(fasta_path),
+        "alphafold_params_dir": str(params_dir),
+        "model_name": model_name,
         "csv": str(csv_path),
         "best_pdb": str(best_path),
         "all_pdb_dir": str(all_pdb_dir),

--- a/sim_tools/unified/src/steps/proteinmpnn_step.py
+++ b/sim_tools/unified/src/steps/proteinmpnn_step.py
@@ -55,22 +55,47 @@ def _parse_contigs(contigs_raw: str) -> List[str]:
 
 def _get_info(contig: str) -> Tuple[List[int], List[bool]]:
     """
-    designability_test.py의 get_info 이식
-    fixed/free를 판단해서 protocol 결정에 사용
+    designability_test.py의 get_info 이식 + 보강
+    - "10" 처럼 하이픈 없는 숫자 세그먼트도 허용
+    - "A1-50/30" 같이 섞인 케이스도 허용
     """
-    F = []
+    F: List[int] = []
     free_chain = False
     fixed_chain = False
-    sub_contigs = [x.split("-") for x in contig.split("/")]
-    for (a, b) in sub_contigs:
-        if a[0].isalpha():
-            L = int(b) - int(a[1:]) + 1
-            F += [1] * L
-            fixed_chain = True
+
+    # contig 예시:
+    #  - "10"
+    #  - "1-10"
+    #  - "A1-50/30"
+    #  - "30/10"
+    for token in contig.split("/"):
+        token = token.strip()
+        if not token:
+            continue
+
+        if "-" in token:
+            a, b = token.split("-", 1)
+
+            # fixed segment: "A1-50"
+            if a and a[0].isalpha():
+                L = int(b) - int(a[1:]) + 1
+                F += [1] * L
+                fixed_chain = True
+            else:
+                # free segment: "1-10" 같은 케이스를 길이로 해석(10)
+                # (designability_test.py는 이런 형태를 거의 안 쓰지만 안전장치)
+                L = int(b)
+                F += [0] * L
+                free_chain = True
         else:
-            L = int(b)
+            # hyphen 없는 숫자: "10" -> free length 10
+            if token[0].isalpha():
+                # 혹시 "A10" 같은 이상 케이스 방어 (사실상 안 씀)
+                raise ValueError(f"invalid contig token without '-': {token}")
+            L = int(token)
             F += [0] * L
             free_chain = True
+
     return F, [fixed_chain, free_chain]
 
 

--- a/sim_tools/unified/src/steps/proteinmpnn_step.py
+++ b/sim_tools/unified/src/steps/proteinmpnn_step.py
@@ -1,0 +1,218 @@
+# /workspace/unified/src/steps/proteinmpnn_step.py
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from colabdesign.mpnn import mk_mpnn_model
+from colabdesign.af import mk_af_model
+from string import ascii_uppercase, ascii_lowercase
+
+alphabet_list = list(ascii_uppercase + ascii_lowercase)
+
+
+@dataclass
+class MPNNStepConfig:
+    experiment_id: str
+    outputs_dir: Path
+    contigs: str = "100"          # 현재 API/args에서 받는 contigs 그대로 사용
+    copies: int = 1               # 우선 1 고정 (필요하면 args로 확장)
+    rm_aa: str | None = "C"
+    num_seqs: int = 8             # iterations 값을 num_seqs로 매핑할 예정
+    mpnn_sampling_temp: float = 0.1
+
+
+def _parse_contigs(contigs_raw: str) -> List[str]:
+    """
+    ColabDesign 쪽 designability_test.py 로직을 최대한 비슷하게 따라감.
+    입력 예: "100" / "A1-50/30" / "50:50" 등
+    """
+    if not contigs_raw:
+        return ["100"]
+
+    contigs_raw = contigs_raw.strip()
+    # RFdiffusion에서 contigs가 "10"처럼 단일 숫자로 오는 케이스 대응
+    # 또는 "10:20"처럼 여러 개면 chain 분리 개념으로 봄
+    parts = contigs_raw.replace(" ", ":").replace(",", ":").split(":")
+    contigs = []
+    for contig_str in parts:
+        contig_str = contig_str.strip()
+        if not contig_str:
+            continue
+        segs = []
+        for x in contig_str.split("/"):
+            if x != "0":
+                segs.append(x)
+        if segs:
+            contigs.append("/".join(segs))
+    return contigs or ["100"]
+
+
+def _get_info(contig: str) -> Tuple[List[int], List[bool]]:
+    """
+    designability_test.py의 get_info 이식
+    fixed/free를 판단해서 protocol 결정에 사용
+    """
+    F = []
+    free_chain = False
+    fixed_chain = False
+    sub_contigs = [x.split("-") for x in contig.split("/")]
+    for (a, b) in sub_contigs:
+        if a[0].isalpha():
+            L = int(b) - int(a[1:]) + 1
+            F += [1] * L
+            fixed_chain = True
+        else:
+            L = int(b)
+            F += [0] * L
+            free_chain = True
+    return F, [fixed_chain, free_chain]
+
+
+def _infer_protocol_and_prep_flags(contigs: List[str], copies: int, rm_aa: str | None):
+    """
+    designability_test.py의 protocol 분기 + prep_flags 생성 로직
+    """
+    chains = alphabet_list[: len(contigs)]
+    info = [_get_info(x) for x in contigs]
+
+    fixed_pos = []
+    fixed_chains = []
+    free_chains = []
+    both_chains = []
+    for pos, (fixed_chain, free_chain) in info:
+        fixed_pos += pos
+        fixed_chains += [fixed_chain and not free_chain]
+        free_chains += [free_chain and not fixed_chain]
+        both_chains += [fixed_chain and free_chain]
+
+    flags = {
+        "initial_guess": False,
+        "best_metric": "rmsd",
+        "use_multimer": False,
+        "model_names": ["model_1_ptm"],
+    }
+
+    if sum(both_chains) == 0 and sum(fixed_chains) > 0 and sum(free_chains) > 0:
+        protocol = "binder"
+        target_chains = []
+        binder_chains = []
+        for n, x in enumerate(fixed_chains):
+            if x:
+                target_chains.append(chains[n])
+            else:
+                binder_chains.append(chains[n])
+        af_model = mk_af_model(protocol="binder", **flags)
+        prep_flags = {
+            "target_chain": ",".join(target_chains),
+            "binder_chain": ",".join(binder_chains),
+            "rm_aa": rm_aa,
+        }
+        fixed_pos_arr = None
+
+    elif sum(fixed_pos) > 0:
+        protocol = "partial"
+        af_model = mk_af_model(protocol="fixbb", use_templates=True, **flags)
+        rm_template = np.array(fixed_pos) == 0
+        prep_flags = {
+            "chain": ",".join(chains),
+            "rm_template": rm_template,
+            "rm_template_seq": rm_template,
+            "copies": copies,
+            "homooligomer": copies > 1,
+            "rm_aa": rm_aa,
+        }
+        fixed_pos_arr = np.array(fixed_pos)
+
+    else:
+        protocol = "fixbb"
+        af_model = mk_af_model(protocol="fixbb", **flags)
+        prep_flags = {
+            "chain": ",".join(chains),
+            "copies": copies,
+            "homooligomer": copies > 1,
+            "rm_aa": rm_aa,
+        }
+        fixed_pos_arr = None
+
+    return protocol, af_model, prep_flags, fixed_pos_arr
+
+
+def run_mpnn_only(cfg: MPNNStepConfig) -> dict:
+    """
+    MPNN-only:
+      - 입력 구조(pdb)로 af_model.prep_inputs만 써서 컨텍스트 구성
+      - MPNN sample만 수행
+      - AlphaFold predict는 절대 안 함
+    """
+    exp = cfg.experiment_id
+    out_dir = cfg.outputs_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    input_pdb = out_dir / f"{exp}_0.pdb"
+    if not input_pdb.exists():
+        raise FileNotFoundError(
+            f"[proteinMPNN] input pdb not found: {input_pdb} "
+            f"(먼저 step=rfdiffusion을 같은 experiment_id로 실행해야 함)"
+        )
+
+    contigs = _parse_contigs(cfg.contigs)
+    rm_aa = cfg.rm_aa if (cfg.rm_aa and cfg.rm_aa.strip()) else None
+
+    protocol, af_model, prep_flags, fixed_pos_arr = _infer_protocol_and_prep_flags(
+        contigs=contigs,
+        copies=cfg.copies,
+        rm_aa=rm_aa,
+    )
+
+    mpnn_model = mk_mpnn_model()
+
+    # designability_test.py에서 batch_size 로직 따라감
+    batch_size = 8
+    if cfg.num_seqs < batch_size:
+        batch_size = cfg.num_seqs
+
+    # 1) AF 입력 준비(구조 읽기만)
+    af_model.prep_inputs(str(input_pdb), **prep_flags)
+    if protocol == "partial" and fixed_pos_arr is not None:
+        p = np.where(fixed_pos_arr)[0]
+        af_model.opt["fix_pos"] = p[p < af_model._len]
+
+    # 2) MPNN에 AF 입력 전달 후 샘플링
+    mpnn_model.get_af_inputs(af_model)
+    out = mpnn_model.sample(
+        num=max(1, cfg.num_seqs // batch_size),
+        batch=batch_size,
+        temperature=float(cfg.mpnn_sampling_temp),
+    )
+
+    # out keys 예상: seq, score 등
+    seqs = out.get("seq", [])
+    scores = out.get("score", [])
+
+    # 3) 파일 저장
+    fasta_path = out_dir / f"{exp}_mpnn.fasta"
+    csv_path = out_dir / f"{exp}_mpnn_results.csv"
+
+    rows = []
+    with open(fasta_path, "w") as f:
+        for i, seq in enumerate(seqs):
+            seq_clean = re.sub(r"[^A-Z/]", "", seq).replace("/", "")
+            score = float(scores[i]) if i < len(scores) else float("nan")
+            f.write(f">mpnn_{i}|score={score:.6f}\n{seq_clean}\n")
+            rows.append({"n": i, "mpnn_score": score, "seq": seq_clean})
+
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+
+    return {
+        "input_pdb": str(input_pdb),
+        "fasta": str(fasta_path),
+        "csv": str(csv_path),
+        "num_seqs": len(rows),
+        "protocol": protocol,
+    }

--- a/sim_tools/unified/unified_shell_script.sh
+++ b/sim_tools/unified/unified_shell_script.sh
@@ -24,12 +24,12 @@ UVICORN_PID="${UVICORN_PID:-${APP_DIR}/uvicorn_${PORT}.pid}"
 # (옵션) S3 업로드 관련 env
 # -----------------------------
 S3_BUCKET="${S3_BUCKET:-}"
-S3_PREFIX="${S3_PREFIX:-rfdiffusion}"
+S3_BASE="${S3_BASE:-simulations}"           # ✅ NEW: base root (default: simulations)
 AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 
 # ✅ AWS_S3_*도 지원 (RunPod Secret에서 AWS_S3_*만 넣어도 동작)
 AWS_S3_BUCKET="${AWS_S3_BUCKET:-}"
-AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"
+AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"   # ex) simulations  (or legacy values)
 
 ########################################
 # Utils
@@ -46,7 +46,7 @@ need_root() {
 ensure_dir() { mkdir -p "$1"; }
 venv_python() { echo "${TORCH_VENV}/bin/python"; }
 
-# ✅ 1번 방식: "비어있으면 env로 넘기지 않기" 헬퍼
+# ✅ "비어있으면 env로 넘기지 않기" 헬퍼
 add_env_if_nonempty() {
   local -n _arr="$1"
   local k="$2"
@@ -59,12 +59,10 @@ add_env_if_nonempty() {
 # ✅ RunPod에서 /proc/1(environ)에만 AWS/S3가 있고 현재 쉘에는 없을 때가 있음
 #    -> 그 경우 PID1의 AWS_/S3_만 안전하게 가져와서 export
 load_aws_env_from_pid1_if_missing() {
-  # 현재 쉘에 AWS_/S3_가 하나라도 있으면 아무것도 안 함
   if env | egrep -q '^(AWS_|S3_)'; then
     return 0
   fi
 
-  # /proc/1/environ 에서 AWS_/S3_만 골라 export
   if [[ -r /proc/1/environ ]]; then
     while IFS= read -r kv; do
       [[ "$kv" == *=* ]] || continue
@@ -73,7 +71,7 @@ load_aws_env_from_pid1_if_missing() {
   fi
 }
 
-# ✅ env 로드 후, AWS_S3_* -> S3_* 매핑 + prefix 정리 + region 보정
+# ✅ env 로드 후, AWS_S3_* -> S3_* 매핑 + base 정리 + region 보정
 refresh_s3_mapping() {
   # region 동기화
   AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
@@ -81,7 +79,6 @@ refresh_s3_mapping() {
     AWS_DEFAULT_REGION="$AWS_REGION"
   fi
 
-  # AWS_S3_* 값 확보
   AWS_S3_BUCKET="${AWS_S3_BUCKET:-}"
   AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"
 
@@ -90,13 +87,17 @@ refresh_s3_mapping() {
     S3_BUCKET="${AWS_S3_BUCKET}"
   fi
 
-  # S3_PREFIX가 비었거나 기본값(rfdiffusion)일 때만 AWS_S3_BASE_PATH로 덮어씀
-  if { [[ -z "${S3_PREFIX:-}" ]] || [[ "${S3_PREFIX}" == "rfdiffusion" ]]; } && [[ -n "${AWS_S3_BASE_PATH:-}" ]]; then
-    S3_PREFIX="${AWS_S3_BASE_PATH}"
+  # ✅ NEW: base root 매핑
+  # - S3_BASE가 비어있을 때만 AWS_S3_BASE_PATH로 채움
+  # - (주의) AWS_S3_BASE_PATH에 "simulations/sim_result" 같은 legacy 값이 들어오면
+  #         최신 구조에서는 base root로는 "simulations"만 쓰는 걸 권장.
+  if [[ -z "${S3_BASE:-}" && -n "${AWS_S3_BASE_PATH:-}" ]]; then
+    S3_BASE="${AWS_S3_BASE_PATH}"
   fi
 
-  # prefix 정리 (양끝 슬래시 제거) + 기본값 보장
-  S3_PREFIX="$(echo "${S3_PREFIX:-rfdiffusion}" | sed 's#^/*##; s#/*$##')"
+  # base 정리 (양끝 슬래시 제거) + 기본값 보장
+  S3_BASE="$(echo "${S3_BASE:-simulations}" | sed 's#^/*##; s#/*$##')"
+  [[ -n "${S3_BASE:-}" ]] || S3_BASE="simulations"
 }
 
 ########################################
@@ -115,7 +116,7 @@ cmd_up() {
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
   log "PORT=$PORT"
   log "S3_BUCKET=${S3_BUCKET:-<empty>}"
-  log "S3_PREFIX=$S3_PREFIX"
+  log "S3_BASE=${S3_BASE:-simulations}"
   log "AWS_REGION=${AWS_REGION:-<empty>}"
   log "AWS_S3_BUCKET=${AWS_S3_BUCKET:-<empty>}"
   log "AWS_S3_BASE_PATH=${AWS_S3_BASE_PATH:-<empty>}"
@@ -370,13 +371,14 @@ cmd_run() {
   log "DGLBACKEND=$DGLBACKEND"
   log "DGL_DISABLE_GRAPHBOLT=$DGL_DISABLE_GRAPHBOLT"
 
-  export PYTHONPATH="$RFDIFFUSION_DIR:${PYTHONPATH:-}"
+  # ✅ FIX: src 를 PYTHONPATH에 추가해서 `from steps...` import 가능하게
+  export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
   log "PYTHONPATH=$PYTHONPATH"
 
   export LD_LIBRARY_PATH="$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvtx/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvjitlink/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nccl/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/curand/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cufft/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_nvrtc/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_cupti/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cublas/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusparse/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cudnn/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusolver/lib:${LD_LIBRARY_PATH:-}"
   log "LD_LIBRARY_PATH set"
 
-  # ✅ 1번 방식: 비어있으면 export 자체를 하지 않음 (빈 값으로 덮어쓰기 방지)
+  # ✅ 비어있으면 export 자체를 하지 않음 (빈 값으로 덮어쓰기 방지)
   if [[ -n "${AWS_REGION:-}" ]]; then
     export AWS_REGION
     export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$AWS_REGION}"
@@ -385,10 +387,10 @@ cmd_run() {
   [[ -n "${AWS_S3_BASE_PATH:-}" ]] && export AWS_S3_BASE_PATH
 
   [[ -n "${S3_BUCKET:-}" ]] && export S3_BUCKET
-  [[ -n "${S3_PREFIX:-}" ]] && export S3_PREFIX
+  [[ -n "${S3_BASE:-}" ]] && export S3_BASE
 
   log "S3_BUCKET=${S3_BUCKET:-<empty>}"
-  log "S3_PREFIX=${S3_PREFIX:-<empty>}"
+  log "S3_BASE=${S3_BASE:-<empty>}"
   log "AWS_REGION=${AWS_REGION:-<empty>}"
 
   ensure_dir "$MODELS_DIR"
@@ -419,19 +421,19 @@ cmd_serve() {
 
   cd "$APP_DIR"
 
-  # ✅ 1번 방법 핵심:
-  #   env ... AWS_REGION="" 같은 "빈 값"을 넘기면 자식 프로세스에서 빈 값으로 덮어써짐.
-  #   따라서 "값이 있을 때만" env로 넘기도록 구성.
+  # ✅ "값이 있을 때만" env로 넘기기
   local env_kv=()
   env_kv+=("SCRIPT_DIR=$SCRIPT_DIR")
   env_kv+=("OPS_SH=$SCRIPT_DIR/unified_shell_script.sh")
   env_kv+=("OUTPUTS_DIR=$OUTPUTS_DIR")
   env_kv+=("TORCH_VENV=$TORCH_VENV")
-  env_kv+=("PYTHONPATH=$RFDIFFUSION_DIR")
+
+  # ✅ FIX: API 서버도 src + rfdiffusion 둘 다 PYTHONPATH에 포함
+  env_kv+=("PYTHONPATH=$SCRIPT_DIR/src:$RFDIFFUSION_DIR")
 
   # S3/AWS는 값이 있을 때만 넘김 (빈 값 전달 금지)
   add_env_if_nonempty env_kv "S3_BUCKET" "${S3_BUCKET:-}"
-  add_env_if_nonempty env_kv "S3_PREFIX" "${S3_PREFIX:-}"
+  add_env_if_nonempty env_kv "S3_BASE" "${S3_BASE:-}"
 
   add_env_if_nonempty env_kv "AWS_REGION" "${AWS_REGION:-}"
   if [[ -n "${AWS_REGION:-}" ]]; then
@@ -517,14 +519,14 @@ Env overrides:
   PORT=8000
 
 S3 upload env (optional):
-  # Preferred (existing)
+  # Preferred
   S3_BUCKET=my-bucket
-  S3_PREFIX=rfdiffusion
+  S3_BASE=simulations
   AWS_REGION=ap-northeast-2
 
   # Also supported (AWS-style)
   AWS_S3_BUCKET=my-bucket
-  AWS_S3_BASE_PATH=simulations/sim_result
+  AWS_S3_BASE_PATH=simulations
   AWS_ACCESS_KEY_ID=...
   AWS_SECRET_ACCESS_KEY=...
 EOF


### PR DESCRIPTION
[주요 변경사항]
- RFdiffusion만 사용 가능하던 기존에서 RFdiffusion / ProteinMPNN / AlphaFold 모델 모두 사용가능하게 끔 수정하였음.
- 각각의 시뮬레이션 툴은 개별적으로도 실행 가능하며 순차적으로 실행할 수도 있음

[실행 절차]
- 런팟 생성
- 런팟 환경변수 적용
```bash
cat >/etc/profile.d/aws_s3_env.sh <<'EOF'
# Load AWS_/S3_ vars from PID 1 into shells (RunPod secrets often live only in PID1 environ)
# Safe to source multiple times.

if [[ -r /proc/1/environ ]]; then
  while IFS= read -r line; do
    case "$line" in
      AWS_*|S3_*)
        export "$line"
        ;;
    esac
  done < <(tr '\0' '\n' </proc/1/environ 2>/dev/null)
fi
EOF

chmod 0644 /etc/profile.d/aws_s3_env.sh
```
```
source /etc/profile.d/aws_s3_env.sh
printenv | egrep '^(AWS_|S3_)'
```

- SCP를 통해 로컬 코드를 런팟으로 전송
- 경로 이동(지금부터는 런팟 터미널에서 실행)
```bash
cd /workspace/unified
```
- 서버 실행
```bash
./unified_shell_script.sh up
# 또는 (이미 install/params 되어있으면)
# ./unified_shell_script.sh serve
```
- 서버 상태 확인
```bash
curl -s http://127.0.0.1:8000/health ; echo
```
< API를 통한 개별 실행>
- RFdiffusion
```bash
curl -s -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{
    "experiment_id": "EXP_0101",
    "step": "rfdiffusion",
    "mode": "backbone",
    "contigs": "10",
    "iterations": 1,
    "s3_upload_logs": true
  }' ; echo
```
- ProteinMPNN
```bash
curl -s -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{
    "experiment_id": "EXP_0101",
    "step": "proteinMPNN",
    "contigs": "10",
    "iterations": 8
  }' ; echo
```
- AlphaFold
```bash
curl -s -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{
    "experiment_id": "EXP_0101",
    "step": "alphafold",
    "iterations": 1
  }' ; echo
```
- 로그 확인
```bash
./unified_shell_script.sh logs:job EXP_0101
# 또는
tail -f /workspace/unified/outputs/_logs/EXP_0101.log
```
- 상태 확인
```bash
curl -s http://127.0.0.1:8000/status/EXP_0101 ; echo
```