### PR TITLE
Feature/sims gpu(각 시뮬레이션 툴들이 GPU를 사용할 수 있게 끔 코드 수정 &  RunPod Simulation 전용 환경변수 분리)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,5 +147,5 @@ TAVILY_API_KEY=your_TAVILY_API_KEY
 ########################################
 # 런팟 베이스 URL & API 키
 ########################################
-RUNPOD_BASE_URL=https://mqaqly7pwybmx0-19123.proxy.runpod.net
-RUNPOD_API_KEY="rpa_~~"
+RUNPOD_SIMS_BASE_URL=https://mqaqly7pwybmx0-19123.proxy.runpod.net
+RUNPOD_SIMS_API_KEY="rpa_~~"

--- a/django_app/apps/experiments/views_runpod.py
+++ b/django_app/apps/experiments/views_runpod.py
@@ -9,22 +9,21 @@ from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
 
 
-def _get_runpod_base_url() -> str:
+def _get_runpod_sims_base_url() -> str:
     """
-    RUNPOD_BASE_URL은 반드시 환경변수(.env)로 주입해야 함.
+    RUNPOD_SIMS_BASE_URL은 반드시 환경변수(.env)로 주입해야 함.
     예) https://xxxx.proxy.runpod.net
     """
-    base = (os.environ.get("RUNPOD_BASE_URL") or "").strip()
+    base = (os.environ.get("RUNPOD_SIMS_BASE_URL") or "").strip()
 
     if not base:
-        # 운영에서 하드코딩으로 넘어가면 사고나기 쉬워서 "없으면 명확히 에러"로 처리
         raise RuntimeError(
-            "RUNPOD_BASE_URL is not set. Put it in .env (RUNPOD_BASE_URL=https://...)"
+            "RUNPOD_SIMS_BASE_URL is not set. Put it in .env (RUNPOD_SIMS_BASE_URL=https://...)"
         )
 
     if not (base.startswith("http://") or base.startswith("https://")):
         raise RuntimeError(
-            f"RUNPOD_BASE_URL must start with http:// or https:// (got: {base})"
+            f"RUNPOD_SIMS_BASE_URL must start with http:// or https:// (got: {base})"
         )
 
     return base.rstrip("/")
@@ -35,14 +34,14 @@ def _headers() -> dict:
         "accept": "application/json",
         "Content-Type": "application/json",
     }
-    api_key = (os.environ.get("RUNPOD_API_KEY") or "").strip()
+    api_key = (os.environ.get("RUNPOD_SIMS_API_KEY") or "").strip()
     if api_key:
         headers["X-API-KEY"] = api_key
     return headers
 
 
 @extend_schema(
-    summary="Run RFdiffusion on RunPod (dummy)",
+    summary="RunPod 연결 테스트 (dummy)",
     description="API가 동작하는지만 테스트하는 더미 API",
     tags=["Experiments"],
     responses={200: {"type": "object"}},
@@ -50,7 +49,7 @@ def _headers() -> dict:
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def rfdiffusion_runpod_api(request):
-    return Response({"detail": "REST API가 동작하는지 확인만 하자!"}, status=200)
+    return Response({"detail": "Django REST API OK"}, status=200)
 
 
 @extend_schema(
@@ -63,7 +62,7 @@ def rfdiffusion_runpod_api(request):
 @permission_classes([IsAuthenticated])
 def runpod_api_health(request):
     try:
-        base = _get_runpod_base_url()
+        base = _get_runpod_sims_base_url()
     except RuntimeError as e:
         return Response({"detail": str(e)}, status=500)
 
@@ -94,12 +93,14 @@ def runpod_api_health(request):
         "application/json": {
             "type": "object",
             "properties": {
+                "experiment_id": {"type": "string", "example": "t_rfd_001"},
+                "step": {"type": "string", "example": "rfdiffusion"},
                 "mode": {"type": "string", "example": "backbone"},
-                "name": {"type": "string", "example": "job_001"},
                 "contigs": {"type": "string", "example": "100"},
                 "iterations": {"type": "integer", "example": 1},
+                "s3_upload_logs": {"type": "boolean", "example": True},
             },
-            "required": ["contigs"],
+            "required": ["experiment_id", "step", "contigs"],
         }
     },
     responses={200: {"type": "object"}},
@@ -111,7 +112,7 @@ def runpod_api_run(request):
         return Response({"detail": "JSON body is required."}, status=400)
 
     try:
-        base = _get_runpod_base_url()
+        base = _get_runpod_sims_base_url()
     except RuntimeError as e:
         return Response({"detail": str(e)}, status=500)
 

--- a/sim_tools/unified/api_server.py
+++ b/sim_tools/unified/api_server.py
@@ -1,221 +1,138 @@
-#!/usr/bin/env python3
+# django_app/apps/experiments/views_runpod.py (FULL)
+
 import os
-import uuid
-import subprocess
-from pathlib import Path
-from typing import Optional, Literal
+import requests
 
-from fastapi import FastAPI, HTTPException, Header
-from pydantic import BaseModel, Field
-
-# ---- Config ----
-SCRIPT_DIR = os.environ.get("SCRIPT_DIR", "/workspace/unified")
-OPS_SH = os.environ.get("OPS_SH", f"{SCRIPT_DIR}/unified_shell_script.sh")
-
-OUTPUTS_DIR = os.environ.get("OUTPUTS_DIR", f"{SCRIPT_DIR}/outputs")
-
-# ✅ torch/jax venv 둘 다 전달
-TORCH_VENV = os.environ.get("TORCH_VENV", "/opt/venv_torch")
-JAX_VENV = os.environ.get("JAX_VENV", "/opt/venv_jax")
-
-PYTHONPATH = os.environ.get("PYTHONPATH", "/app/RFdiffusion")
-
-API_KEY = os.environ.get("API_KEY")  # 설정 안 하면 인증 없이 동작
-
-app = FastAPI(title="Unified Runner API")
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from drf_spectacular.utils import extend_schema
 
 
-# ---------------- Models ----------------
-class RunRequest(BaseModel):
-    mode: Literal["backbone", "binder", "other"] = "backbone"
+def _get_runpod_sims_base_url() -> str:
+    """
+    RUNPOD_SIMS_BASE_URL은 반드시 환경변수(.env)로 주입해야 함.
+    예) https://xxxx.proxy.runpod.net
+    """
+    base = (os.environ.get("RUNPOD_SIMS_BASE_URL") or "").strip()
 
-    # ⚠️ 기존 호환을 위해 남겨두되, 실제 실행에서는 무시함
-    name: Optional[str] = None
-
-    contigs: str = Field(default="100")
-    iterations: int = Field(default=1, ge=1, le=1000)
-
-    # ✅ S3 경로 규칙에 필요한 값
-    experiment_id: str = Field(..., description="pipeline=EXPERIMENT_ID (queue에서 받은 값)")
-    step: Literal["rfdiffusion", "alphafold", "proteinMPNN"] = Field(
-        default="rfdiffusion",
-        description="step=TOOL_NAME"
-    )
-
-    # ✅ (선택) 로그 업로드
-    s3_upload_logs: bool = Field(default=False)
-
-
-class RunResponse(BaseModel):
-    ok: bool
-    job_id: str
-    name: str
-    outputs_dir: str
-    cmd: list[str]
-
-
-class StatusResponse(BaseModel):
-    ok: bool
-    job_id: str
-    name: str
-    status: str
-    log_path: str
-    expected_pdb: str
-
-
-# ---------------- Utils ----------------
-def _ensure_paths():
-    if not Path(OPS_SH).is_file():
-        raise RuntimeError(f"unified_shell_script.sh not found: {OPS_SH}")
-    Path(OUTPUTS_DIR).mkdir(parents=True, exist_ok=True)
-
-
-def _auth_or_throw(x_api_key: Optional[str]):
-    if API_KEY and x_api_key != API_KEY:
-        raise HTTPException(status_code=401, detail="Invalid API key")
-
-
-def _job_paths(name: str):
-    logs_dir = Path(OUTPUTS_DIR) / "_logs"
-    logs_dir.mkdir(parents=True, exist_ok=True)
-    log_path = logs_dir / f"{name}.log"
-    pid_path = logs_dir / f"{name}.pid"
-    return log_path, pid_path
-
-
-def _status_from_files(name: str) -> str:
-    pdb0 = Path(OUTPUTS_DIR) / f"{name}_0.pdb"
-    _log_path, pid_path = _job_paths(name)
-
-    if pdb0.exists():
-        return "done"
-
-    if pid_path.exists():
-        try:
-            pid = int(pid_path.read_text().strip())
-            if Path(f"/proc/{pid}").exists():
-                return "running"
-            else:
-                return "failed"
-        except Exception:
-            return "unknown"
-
-    return "unknown"
-
-
-# ---------------- Routes ----------------
-@app.get("/health")
-def health():
-    _ensure_paths()
-    return {
-        "ok": True,
-        "ops_sh": OPS_SH,
-        "outputs_dir": OUTPUTS_DIR,
-        "torch_venv": TORCH_VENV,
-        "jax_venv": JAX_VENV,
-        "pythonpath": PYTHONPATH,
-
-        "enable_jax_cuda": os.environ.get("ENABLE_JAX_CUDA", ""),
-        "ld_library_path": os.environ.get("LD_LIBRARY_PATH", ""),
-
-        "s3_bucket": os.environ.get("S3_BUCKET", ""),
-        "s3_base": os.environ.get("S3_BASE", "simulations"),
-        "aws_region": os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "")),
-
-        "aws_s3_bucket": os.environ.get("AWS_S3_BUCKET", ""),
-        "aws_s3_base_path": os.environ.get("AWS_S3_BASE_PATH", ""),
-    }
-
-
-@app.post("/run", response_model=RunResponse)
-def run(req: RunRequest, x_api_key: Optional[str] = Header(default=None, convert_underscores=False)):
-    _auth_or_throw(x_api_key)
-    _ensure_paths()
-
-    experiment_id = req.experiment_id.strip()
-    if not experiment_id:
-        raise HTTPException(status_code=400, detail="experiment_id is required")
-
-    # ✅ 팀장님 지시: pipeline(=experiment_id) 하나가 job 하나
-    name = experiment_id
-
-    # job_id는 추적/응답용으로만 유지 (파일/폴더에는 사용 안 함)
-    job_id = uuid.uuid4().hex[:12]
-
-    log_path, pid_path = _job_paths(name)
-
-    # ✅ main.py에 experiment_id / step 전달
-    args = [
-        "run",
-        "--mode", req.mode,
-        "--name", name,
-        "--contigs", req.contigs,
-        "--iterations", str(req.iterations),
-
-        "--experiment_id", experiment_id,
-        "--step", req.step,
-    ]
-    if req.s3_upload_logs:
-        args.append("--s3_upload_logs")
-
-    env = os.environ.copy()
-
-    # ✅ venv / pythonpath / outputs / script 전달
-    env["TORCH_VENV"] = TORCH_VENV
-    env["JAX_VENV"] = JAX_VENV
-    env["PYTHONPATH"] = PYTHONPATH
-    env["OUTPUTS_DIR"] = OUTPUTS_DIR
-    env["SCRIPT_DIR"] = SCRIPT_DIR
-
-    # ✅ JAX GPU 강제 활성화 (API 서버 경유로도 반드시 적용)
-    env["ENABLE_JAX_CUDA"] = "1"
-
-    # ✅ LD_LIBRARY_PATH 오염 방지: 빈 값으로 시작
-    # (실제 CUDA/NVIDIA libs 경로는 unified_shell_script.sh가 step별로 다시 세팅)
-    env["LD_LIBRARY_PATH"] = ""
-
-    # ✅ S3/AWS env 전달
-    env["S3_BUCKET"] = os.environ.get("S3_BUCKET", "")
-    env["S3_BASE"] = os.environ.get("S3_BASE", "simulations")
-    env["AWS_REGION"] = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", ""))
-    env["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION", env["AWS_REGION"])
-
-    env["AWS_S3_BUCKET"] = os.environ.get("AWS_S3_BUCKET", "")
-    env["AWS_S3_BASE_PATH"] = os.environ.get("AWS_S3_BASE_PATH", "")
-
-    with open(log_path, "ab") as f:
-        p = subprocess.Popen(
-            ["bash", OPS_SH, *args],
-            env=env,
-            stdout=f,
-            stderr=subprocess.STDOUT,
-            cwd=SCRIPT_DIR,
+    if not base:
+        # 운영에서 하드코딩으로 넘어가면 사고나기 쉬워서 "없으면 명확히 에러"로 처리
+        raise RuntimeError(
+            "RUNPOD_SIMS_BASE_URL is not set. Put it in .env (RUNPOD_SIMS_BASE_URL=https://...)"
         )
 
-    pid_path.write_text(str(p.pid))
+    if not (base.startswith("http://") or base.startswith("https://")):
+        raise RuntimeError(
+            f"RUNPOD_SIMS_BASE_URL must start with http:// or https:// (got: {base})"
+        )
 
-    return RunResponse(
-        ok=True,
-        job_id=job_id,
-        name=name,
-        outputs_dir=OUTPUTS_DIR,
-        cmd=["bash", OPS_SH, *args],
-    )
+    return base.rstrip("/")
 
 
-@app.get("/status/{name}", response_model=StatusResponse)
-def status(name: str, x_api_key: Optional[str] = Header(default=None, convert_underscores=False)):
-    _auth_or_throw(x_api_key)
-    _ensure_paths()
+def _headers() -> dict:
+    headers = {
+        "accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    api_key = (os.environ.get("RUNPOD_SIMS_API_KEY") or "").strip()
+    if api_key:
+        headers["X-API-KEY"] = api_key
+    return headers
 
-    log_path, _ = _job_paths(name)
-    st = _status_from_files(name)
 
-    return StatusResponse(
-        ok=True,
-        job_id="(use name)",
-        name=name,
-        status=st,
-        log_path=str(log_path),
-        expected_pdb=str(Path(OUTPUTS_DIR) / f"{name}_0.pdb"),
-    )
+@extend_schema(
+    summary="Run RFdiffusion on RunPod (dummy)",
+    description="API가 동작하는지만 테스트하는 더미 API",
+    tags=["Experiments"],
+    responses={200: {"type": "object"}},
+)
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def rfdiffusion_runpod_api(request):
+    return Response({"detail": "REST API가 동작하는지 확인만 하자!"}, status=200)
+
+
+@extend_schema(
+    summary="Check RunPod health",
+    description="Proxy a health check request to the configured RunPod endpoint.",
+    tags=["Experiments"],
+    responses={200: {"type": "object"}},
+)
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def runpod_api_health(request):
+    try:
+        base = _get_runpod_sims_base_url()
+    except RuntimeError as e:
+        return Response({"detail": str(e)}, status=500)
+
+    health_url = f"{base}/health"
+
+    try:
+        resp = requests.get(
+            health_url,
+            headers={"accept": "application/json"},
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        return Response({"detail": f"RunPod health request failed: {exc}"}, status=502)
+
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {"detail": resp.text}
+
+    return Response(data, status=resp.status_code)
+
+
+@extend_schema(
+    summary="Trigger RunPod run",
+    description="Forward POST payload to the RunPod /run endpoint deployed via unified/api_server.py.",
+    tags=["Experiments"],
+    request={
+        "application/json": {
+            "type": "object",
+            "properties": {
+                "mode": {"type": "string", "example": "backbone"},
+                "name": {"type": "string", "example": "job_001"},
+                "contigs": {"type": "string", "example": "100"},
+                "iterations": {"type": "integer", "example": 1},
+                "experiment_id": {"type": "string", "example": "t_rfd_001"},
+                "step": {"type": "string", "example": "rfdiffusion"},
+                "s3_upload_logs": {"type": "boolean", "example": True},
+            },
+            "required": ["experiment_id", "step", "contigs"],
+        }
+    },
+    responses={200: {"type": "object"}},
+)
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def runpod_api_run(request):
+    if not isinstance(request.data, dict):
+        return Response({"detail": "JSON body is required."}, status=400)
+
+    try:
+        base = _get_runpod_sims_base_url()
+    except RuntimeError as e:
+        return Response({"detail": str(e)}, status=500)
+
+    run_url = f"{base}/run"
+
+    try:
+        resp = requests.post(
+            run_url,
+            json=request.data,
+            headers=_headers(),
+            timeout=60,
+        )
+    except requests.RequestException as exc:
+        return Response({"detail": f"RunPod run request failed: {exc}"}, status=502)
+
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {"detail": resp.text}
+
+    return Response(data, status=resp.status_code)

--- a/sim_tools/unified/api_server.py
+++ b/sim_tools/unified/api_server.py
@@ -1,138 +1,202 @@
-# django_app/apps/experiments/views_runpod.py (FULL)
-
+#!/usr/bin/env python3
 import os
-import requests
+import uuid
+import subprocess
+from pathlib import Path
+from typing import Optional, Literal
 
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from drf_spectacular.utils import extend_schema
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
 
+# ---- Config ----
+SCRIPT_DIR = os.environ.get("SCRIPT_DIR", "/workspace/unified")
+OPS_SH = os.environ.get("OPS_SH", f"{SCRIPT_DIR}/unified_shell_script.sh")
+OUTPUTS_DIR = os.environ.get("OUTPUTS_DIR", f"{SCRIPT_DIR}/outputs")
 
-def _get_runpod_sims_base_url() -> str:
-    """
-    RUNPOD_SIMS_BASE_URL은 반드시 환경변수(.env)로 주입해야 함.
-    예) https://xxxx.proxy.runpod.net
-    """
-    base = (os.environ.get("RUNPOD_SIMS_BASE_URL") or "").strip()
+TORCH_VENV = os.environ.get("TORCH_VENV", "/opt/venv_torch")
+JAX_VENV = os.environ.get("JAX_VENV", "/opt/venv_jax")
 
-    if not base:
-        # 운영에서 하드코딩으로 넘어가면 사고나기 쉬워서 "없으면 명확히 에러"로 처리
-        raise RuntimeError(
-            "RUNPOD_SIMS_BASE_URL is not set. Put it in .env (RUNPOD_SIMS_BASE_URL=https://...)"
-        )
+# unified_shell_script.sh 내부에서 PYTHONPATH도 세팅하지만, 안전하게 기본값 유지
+PYTHONPATH = os.environ.get("PYTHONPATH", "/app/RFdiffusion")
 
-    if not (base.startswith("http://") or base.startswith("https://")):
-        raise RuntimeError(
-            f"RUNPOD_SIMS_BASE_URL must start with http:// or https:// (got: {base})"
-        )
-
-    return base.rstrip("/")
+app = FastAPI(title="Unified Runner API")
 
 
-def _headers() -> dict:
-    headers = {
-        "accept": "application/json",
-        "Content-Type": "application/json",
+# ---------------- Models ----------------
+class RunRequest(BaseModel):
+    mode: Literal["backbone", "binder", "other"] = "backbone"
+
+    # (호환용) name을 받아도 실제 파일명은 experiment_id로 고정
+    name: Optional[str] = None
+
+    contigs: str = Field(default="100")
+    iterations: int = Field(default=1, ge=1, le=1000)
+
+    experiment_id: str = Field(..., description="pipeline=EXPERIMENT_ID (queue에서 받은 값)")
+    step: Literal["rfdiffusion", "alphafold", "proteinMPNN"] = Field(
+        default="rfdiffusion",
+        description="step=TOOL_NAME"
+    )
+
+    s3_upload_logs: bool = Field(default=False)
+
+
+class RunResponse(BaseModel):
+    ok: bool
+    job_id: str
+    name: str
+    outputs_dir: str
+    cmd: list[str]
+
+
+class StatusResponse(BaseModel):
+    ok: bool
+    job_id: str
+    name: str
+    status: str
+    log_path: str
+    expected_pdb: str
+
+
+# ---------------- Utils ----------------
+def _ensure_paths():
+    if not Path(OPS_SH).is_file():
+        raise RuntimeError(f"unified_shell_script.sh not found: {OPS_SH}")
+    Path(OUTPUTS_DIR).mkdir(parents=True, exist_ok=True)
+
+
+def _job_paths(name: str):
+    logs_dir = Path(OUTPUTS_DIR) / "_logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / f"{name}.log"
+    pid_path = logs_dir / f"{name}.pid"
+    return log_path, pid_path
+
+
+def _status_from_files(name: str) -> str:
+    pdb0 = Path(OUTPUTS_DIR) / f"{name}_0.pdb"
+    _log_path, pid_path = _job_paths(name)
+
+    if pdb0.exists():
+        return "done"
+
+    if pid_path.exists():
+        try:
+            pid = int(pid_path.read_text().strip())
+            if Path(f"/proc/{pid}").exists():
+                return "running"
+            else:
+                return "failed"
+        except Exception:
+            return "unknown"
+
+    return "unknown"
+
+
+# ---------------- Routes ----------------
+@app.get("/health")
+def health():
+    _ensure_paths()
+    return {
+        "ok": True,
+        "ops_sh": OPS_SH,
+        "outputs_dir": OUTPUTS_DIR,
+        "torch_venv": TORCH_VENV,
+        "jax_venv": JAX_VENV,
+        "pythonpath": PYTHONPATH,
+
+        # 디버깅용 환경 변수 노출
+        "enable_jax_cuda": os.environ.get("ENABLE_JAX_CUDA", ""),
+        "ld_library_path": os.environ.get("LD_LIBRARY_PATH", ""),
+
+        "s3_bucket": os.environ.get("S3_BUCKET", ""),
+        "s3_base": os.environ.get("S3_BASE", "simulations"),
+        "aws_region": os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "")),
+
+        "aws_s3_bucket": os.environ.get("AWS_S3_BUCKET", ""),
+        "aws_s3_base_path": os.environ.get("AWS_S3_BASE_PATH", ""),
     }
-    api_key = (os.environ.get("RUNPOD_SIMS_API_KEY") or "").strip()
-    if api_key:
-        headers["X-API-KEY"] = api_key
-    return headers
 
 
-@extend_schema(
-    summary="Run RFdiffusion on RunPod (dummy)",
-    description="API가 동작하는지만 테스트하는 더미 API",
-    tags=["Experiments"],
-    responses={200: {"type": "object"}},
-)
-@api_view(["POST"])
-@permission_classes([IsAuthenticated])
-def rfdiffusion_runpod_api(request):
-    return Response({"detail": "REST API가 동작하는지 확인만 하자!"}, status=200)
+@app.post("/run", response_model=RunResponse)
+def run(req: RunRequest):
+    _ensure_paths()
 
+    experiment_id = req.experiment_id.strip()
+    if not experiment_id:
+        raise HTTPException(status_code=400, detail="experiment_id is required")
 
-@extend_schema(
-    summary="Check RunPod health",
-    description="Proxy a health check request to the configured RunPod endpoint.",
-    tags=["Experiments"],
-    responses={200: {"type": "object"}},
-)
-@api_view(["GET"])
-@permission_classes([IsAuthenticated])
-def runpod_api_health(request):
-    try:
-        base = _get_runpod_sims_base_url()
-    except RuntimeError as e:
-        return Response({"detail": str(e)}, status=500)
+    # ✅ 파일/로그 이름은 experiment_id 고정
+    name = experiment_id
 
-    health_url = f"{base}/health"
+    job_id = uuid.uuid4().hex[:12]
+    log_path, pid_path = _job_paths(name)
 
-    try:
-        resp = requests.get(
-            health_url,
-            headers={"accept": "application/json"},
-            timeout=15,
+    args = [
+        "run",
+        "--mode", req.mode,
+        "--name", name,
+        "--contigs", req.contigs,
+        "--iterations", str(req.iterations),
+        "--experiment_id", experiment_id,
+        "--step", req.step,
+    ]
+    if req.s3_upload_logs:
+        args.append("--s3_upload_logs")
+
+    env = os.environ.copy()
+
+    # ✅ venv / 경로 전달
+    env["TORCH_VENV"] = TORCH_VENV
+    env["JAX_VENV"] = JAX_VENV
+    env["PYTHONPATH"] = PYTHONPATH
+    env["OUTPUTS_DIR"] = OUTPUTS_DIR
+    env["SCRIPT_DIR"] = SCRIPT_DIR
+
+    # ✅ GPU/JAX 이슈 재발 방지: 기본으로 세팅
+    env["ENABLE_JAX_CUDA"] = env.get("ENABLE_JAX_CUDA", "1")
+    env["LD_LIBRARY_PATH"] = ""  # 외부 LD_LIBRARY_PATH 오염 차단 (unified_shell_script.sh가 step별로 재설정)
+
+    # ✅ S3/AWS env 전달
+    env["S3_BUCKET"] = env.get("S3_BUCKET", "")
+    env["S3_BASE"] = env.get("S3_BASE", "simulations")
+    env["AWS_REGION"] = env.get("AWS_REGION", env.get("AWS_DEFAULT_REGION", ""))
+    env["AWS_DEFAULT_REGION"] = env.get("AWS_DEFAULT_REGION", env["AWS_REGION"])
+    env["AWS_S3_BUCKET"] = env.get("AWS_S3_BUCKET", "")
+    env["AWS_S3_BASE_PATH"] = env.get("AWS_S3_BASE_PATH", "")
+
+    with open(log_path, "ab") as f:
+        p = subprocess.Popen(
+            ["bash", OPS_SH, *args],
+            env=env,
+            stdout=f,
+            stderr=subprocess.STDOUT,
+            cwd=SCRIPT_DIR,
         )
-    except requests.RequestException as exc:
-        return Response({"detail": f"RunPod health request failed: {exc}"}, status=502)
 
-    try:
-        data = resp.json()
-    except ValueError:
-        data = {"detail": resp.text}
+    pid_path.write_text(str(p.pid))
 
-    return Response(data, status=resp.status_code)
+    return RunResponse(
+        ok=True,
+        job_id=job_id,
+        name=name,
+        outputs_dir=OUTPUTS_DIR,
+        cmd=["bash", OPS_SH, *args],
+    )
 
 
-@extend_schema(
-    summary="Trigger RunPod run",
-    description="Forward POST payload to the RunPod /run endpoint deployed via unified/api_server.py.",
-    tags=["Experiments"],
-    request={
-        "application/json": {
-            "type": "object",
-            "properties": {
-                "mode": {"type": "string", "example": "backbone"},
-                "name": {"type": "string", "example": "job_001"},
-                "contigs": {"type": "string", "example": "100"},
-                "iterations": {"type": "integer", "example": 1},
-                "experiment_id": {"type": "string", "example": "t_rfd_001"},
-                "step": {"type": "string", "example": "rfdiffusion"},
-                "s3_upload_logs": {"type": "boolean", "example": True},
-            },
-            "required": ["experiment_id", "step", "contigs"],
-        }
-    },
-    responses={200: {"type": "object"}},
-)
-@api_view(["POST"])
-@permission_classes([IsAuthenticated])
-def runpod_api_run(request):
-    if not isinstance(request.data, dict):
-        return Response({"detail": "JSON body is required."}, status=400)
+@app.get("/status/{name}", response_model=StatusResponse)
+def status(name: str):
+    _ensure_paths()
 
-    try:
-        base = _get_runpod_sims_base_url()
-    except RuntimeError as e:
-        return Response({"detail": str(e)}, status=500)
+    log_path, _ = _job_paths(name)
+    st = _status_from_files(name)
 
-    run_url = f"{base}/run"
-
-    try:
-        resp = requests.post(
-            run_url,
-            json=request.data,
-            headers=_headers(),
-            timeout=60,
-        )
-    except requests.RequestException as exc:
-        return Response({"detail": f"RunPod run request failed: {exc}"}, status=502)
-
-    try:
-        data = resp.json()
-    except ValueError:
-        data = {"detail": resp.text}
-
-    return Response(data, status=resp.status_code)
+    return StatusResponse(
+        ok=True,
+        job_id="(use name)",
+        name=name,
+        status=st,
+        log_path=str(log_path),
+        expected_pdb=str(Path(OUTPUTS_DIR) / f"{name}_0.pdb"),
+    )

--- a/sim_tools/unified/api_server.py
+++ b/sim_tools/unified/api_server.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Literal
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from pydantic import BaseModel, Field
 
 # ---- Config ----
@@ -115,6 +115,9 @@ def health():
         "jax_venv": JAX_VENV,
         "pythonpath": PYTHONPATH,
 
+        "enable_jax_cuda": os.environ.get("ENABLE_JAX_CUDA", ""),
+        "ld_library_path": os.environ.get("LD_LIBRARY_PATH", ""),
+
         "s3_bucket": os.environ.get("S3_BUCKET", ""),
         "s3_base": os.environ.get("S3_BASE", "simulations"),
         "aws_region": os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "")),
@@ -125,7 +128,7 @@ def health():
 
 
 @app.post("/run", response_model=RunResponse)
-def run(req: RunRequest, x_api_key: Optional[str] = None):
+def run(req: RunRequest, x_api_key: Optional[str] = Header(default=None, convert_underscores=False)):
     _auth_or_throw(x_api_key)
     _ensure_paths()
 
@@ -156,13 +159,22 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
         args.append("--s3_upload_logs")
 
     env = os.environ.copy()
+
+    # ✅ venv / pythonpath / outputs / script 전달
     env["TORCH_VENV"] = TORCH_VENV
     env["JAX_VENV"] = JAX_VENV
     env["PYTHONPATH"] = PYTHONPATH
     env["OUTPUTS_DIR"] = OUTPUTS_DIR
     env["SCRIPT_DIR"] = SCRIPT_DIR
 
-    # S3/AWS env 전달
+    # ✅ JAX GPU 강제 활성화 (API 서버 경유로도 반드시 적용)
+    env["ENABLE_JAX_CUDA"] = "1"
+
+    # ✅ LD_LIBRARY_PATH 오염 방지: 빈 값으로 시작
+    # (실제 CUDA/NVIDIA libs 경로는 unified_shell_script.sh가 step별로 다시 세팅)
+    env["LD_LIBRARY_PATH"] = ""
+
+    # ✅ S3/AWS env 전달
     env["S3_BUCKET"] = os.environ.get("S3_BUCKET", "")
     env["S3_BASE"] = os.environ.get("S3_BASE", "simulations")
     env["AWS_REGION"] = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", ""))
@@ -192,7 +204,7 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
 
 
 @app.get("/status/{name}", response_model=StatusResponse)
-def status(name: str, x_api_key: Optional[str] = None):
+def status(name: str, x_api_key: Optional[str] = Header(default=None, convert_underscores=False)):
     _auth_or_throw(x_api_key)
     _ensure_paths()
 

--- a/sim_tools/unified/api_server.py
+++ b/sim_tools/unified/api_server.py
@@ -16,20 +16,29 @@ OUTPUTS_DIR = os.environ.get("OUTPUTS_DIR", f"{SCRIPT_DIR}/outputs")
 TORCH_VENV = os.environ.get("TORCH_VENV", "/opt/venv_torch")
 PYTHONPATH = os.environ.get("PYTHONPATH", "/app/RFdiffusion")
 
-# (선택) 간단한 보호장치
 API_KEY = os.environ.get("API_KEY")  # 설정 안 하면 인증 없이 동작
 
-app = FastAPI(title="RFdiffusion Runner API")
+app = FastAPI(title="Unified Runner API")
 
 
 # ---------------- Models ----------------
 class RunRequest(BaseModel):
     mode: Literal["backbone", "binder", "other"] = "backbone"
+
+    # ⚠️ 기존 호환을 위해 남겨두되, 실제 실행에서는 무시함
     name: Optional[str] = None
+
     contigs: str = Field(default="100")
     iterations: int = Field(default=1, ge=1, le=1000)
 
-    # ✅ (선택) API 요청에서 로그 업로드까지 하고 싶으면 true
+    # ✅ S3 경로 규칙에 필요한 값
+    experiment_id: str = Field(..., description="pipeline=EXPERIMENT_ID (queue에서 받은 값)")
+    step: Literal["rfdiffusion", "alphafold", "proteinMPNN"] = Field(
+        default="rfdiffusion",
+        description="step=TOOL_NAME"
+    )
+
+    # ✅ (선택) 로그 업로드
     s3_upload_logs: bool = Field(default=False)
 
 
@@ -101,12 +110,10 @@ def health():
         "torch_venv": TORCH_VENV,
         "pythonpath": PYTHONPATH,
 
-        # 기존(최종적으로 쓰이는 값)
         "s3_bucket": os.environ.get("S3_BUCKET", ""),
-        "s3_prefix": os.environ.get("S3_PREFIX", "rfdiffusion"),
+        "s3_base": os.environ.get("S3_BASE", "simulations"),
         "aws_region": os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "")),
 
-        # ✅ 추가: RunPod에 AWS_S3_*로 넣었을 때 디버깅 편하게 같이 노출
         "aws_s3_bucket": os.environ.get("AWS_S3_BUCKET", ""),
         "aws_s3_base_path": os.environ.get("AWS_S3_BASE_PATH", ""),
     }
@@ -117,18 +124,28 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     _auth_or_throw(x_api_key)
     _ensure_paths()
 
+    experiment_id = req.experiment_id.strip()
+    if not experiment_id:
+        raise HTTPException(status_code=400, detail="experiment_id is required")
+
+    # ✅ 팀장님 지시: pipeline(=experiment_id) 하나가 job 하나
+    name = experiment_id
+
+    # job_id는 추적/응답용으로만 유지 (파일/폴더에는 사용 안 함)
     job_id = uuid.uuid4().hex[:12]
-    name = req.name or f"job_{job_id}"
 
     log_path, pid_path = _job_paths(name)
 
-    # ✅ 여기서 main.py에 s3_upload_logs 옵션을 넘겨줄지 결정
+    # ✅ main.py에 experiment_id / step 전달
     args = [
         "run",
         "--mode", req.mode,
-        "--name", name,
+        "--name", name,                 # ✅ EXP_0001
         "--contigs", req.contigs,
         "--iterations", str(req.iterations),
+
+        "--experiment_id", experiment_id,
+        "--step", req.step,
     ]
     if req.s3_upload_logs:
         args.append("--s3_upload_logs")
@@ -139,13 +156,12 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     env["OUTPUTS_DIR"] = OUTPUTS_DIR
     env["SCRIPT_DIR"] = SCRIPT_DIR
 
-    # ✅ 중요: S3 관련 env를 자식 프로세스(run)에도 확실히 전달
+    # S3/AWS env 전달
     env["S3_BUCKET"] = os.environ.get("S3_BUCKET", "")
-    env["S3_PREFIX"] = os.environ.get("S3_PREFIX", "rfdiffusion")
+    env["S3_BASE"] = os.environ.get("S3_BASE", "simulations")
     env["AWS_REGION"] = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", ""))
     env["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION", env["AWS_REGION"])
 
-    # ✅ (디버깅/호환) AWS_S3_*도 그대로 전달해두면 run 쪽에서 확인하기 쉬움
     env["AWS_S3_BUCKET"] = os.environ.get("AWS_S3_BUCKET", "")
     env["AWS_S3_BASE_PATH"] = os.environ.get("AWS_S3_BASE_PATH", "")
 
@@ -163,7 +179,7 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     return RunResponse(
         ok=True,
         job_id=job_id,
-        name=name,
+        name=name,  # ✅ EXP_0001
         outputs_dir=OUTPUTS_DIR,
         cmd=["bash", OPS_SH, *args],
     )

--- a/sim_tools/unified/api_server.py
+++ b/sim_tools/unified/api_server.py
@@ -13,7 +13,11 @@ SCRIPT_DIR = os.environ.get("SCRIPT_DIR", "/workspace/unified")
 OPS_SH = os.environ.get("OPS_SH", f"{SCRIPT_DIR}/unified_shell_script.sh")
 
 OUTPUTS_DIR = os.environ.get("OUTPUTS_DIR", f"{SCRIPT_DIR}/outputs")
+
+# ✅ torch/jax venv 둘 다 전달
 TORCH_VENV = os.environ.get("TORCH_VENV", "/opt/venv_torch")
+JAX_VENV = os.environ.get("JAX_VENV", "/opt/venv_jax")
+
 PYTHONPATH = os.environ.get("PYTHONPATH", "/app/RFdiffusion")
 
 API_KEY = os.environ.get("API_KEY")  # 설정 안 하면 인증 없이 동작
@@ -108,6 +112,7 @@ def health():
         "ops_sh": OPS_SH,
         "outputs_dir": OUTPUTS_DIR,
         "torch_venv": TORCH_VENV,
+        "jax_venv": JAX_VENV,
         "pythonpath": PYTHONPATH,
 
         "s3_bucket": os.environ.get("S3_BUCKET", ""),
@@ -140,7 +145,7 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     args = [
         "run",
         "--mode", req.mode,
-        "--name", name,                 # ✅ EXP_0001
+        "--name", name,
         "--contigs", req.contigs,
         "--iterations", str(req.iterations),
 
@@ -152,6 +157,7 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
 
     env = os.environ.copy()
     env["TORCH_VENV"] = TORCH_VENV
+    env["JAX_VENV"] = JAX_VENV
     env["PYTHONPATH"] = PYTHONPATH
     env["OUTPUTS_DIR"] = OUTPUTS_DIR
     env["SCRIPT_DIR"] = SCRIPT_DIR
@@ -179,7 +185,7 @@ def run(req: RunRequest, x_api_key: Optional[str] = None):
     return RunResponse(
         ok=True,
         job_id=job_id,
-        name=name,  # ✅ EXP_0001
+        name=name,
         outputs_dir=OUTPUTS_DIR,
         cmd=["bash", OPS_SH, *args],
     )

--- a/sim_tools/unified/src/main.py
+++ b/sim_tools/unified/src/main.py
@@ -4,6 +4,7 @@ import sys
 import argparse
 import subprocess
 from pathlib import Path
+from datetime import datetime, timezone, timedelta
 
 
 def resolve_rfdiffusion_entry() -> str:
@@ -48,57 +49,53 @@ def pick_python() -> str:
 
 
 def _get_s3_bucket_default() -> str:
-    """
-    Priority:
-      1) S3_BUCKET
-      2) AWS_S3_BUCKET
-    """
     return (os.environ.get("S3_BUCKET") or os.environ.get("AWS_S3_BUCKET") or "").strip()
 
 
-def _get_s3_prefix_default() -> str:
-    """
-    Priority:
-      1) S3_PREFIX
-      2) AWS_S3_BASE_PATH
-      3) rfdiffusion
-    Normalize: strip leading/trailing slashes.
-    """
-    raw = os.environ.get("S3_PREFIX") or os.environ.get("AWS_S3_BASE_PATH") or "rfdiffusion"
-    return str(raw).strip().strip("/")
+def _get_s3_base_default() -> str:
+    return (os.environ.get("S3_BASE") or "simulations").strip().strip("/")
+
+
+def _kst_today() -> str:
+    kst = timezone(timedelta(hours=9))
+    return datetime.now(tz=kst).strftime("%Y-%m-%d")
+
+
+def build_s3_prefix(base: str, dt: str, experiment_id: str, step: str) -> str:
+    base = (base or "simulations").strip().strip("/")
+    dt = dt.strip()
+    experiment_id = experiment_id.strip()
+    step = step.strip()
+    return f"{base}/dt={dt}/pipeline={experiment_id}/step={step}"
 
 
 def parse_args():
     p = argparse.ArgumentParser()
 
     p.add_argument("--mode", default="backbone", choices=["backbone", "binder", "other"])
-    p.add_argument("--name", default="test_rfd")
-    p.add_argument(
-        "--contigs",
-        default="100",
-        help="RFdiffusion contig string, e.g. 100 or 'A1-100' or 'A1-50 0 A51-100'",
-    )
-    p.add_argument("--iterations", type=int, default=50, help="num designs")
-    p.add_argument("--cautious", action="store_true", help="Set inference.cautious=True (skip existing outputs)")
+
+    # ⚠️ 여전히 받을 수는 있지만 실제로는 experiment_id로 덮어씀 (호환용)
+    p.add_argument("--name", default="test_job")
+
+    p.add_argument("--contigs", default="100")
+    p.add_argument("--iterations", type=int, default=1)
+    p.add_argument("--cautious", action="store_true")
 
     p.add_argument("--rfdiffusion_entry", default=resolve_rfdiffusion_entry())
     p.add_argument("--outputs_dir", default=os.environ.get("OUTPUTS_DIR", "/outputs"))
-    p.add_argument("--models_dir", default=os.environ.get("MODELS_DIR", "/models"))
 
-    # ✅ S3 업로드 옵션 (S3_*가 없으면 AWS_S3_* fallback 지원)
-    p.add_argument(
-        "--s3_bucket",
-        default=_get_s3_bucket_default(),
-        help="If set, upload outputs to S3",
-    )
-    p.add_argument(
-        "--s3_prefix",
-        default=_get_s3_prefix_default(),
-        help="S3 key prefix (folder path). Default uses S3_PREFIX or AWS_S3_BASE_PATH or 'rfdiffusion'",
-    )
-    p.add_argument("--s3_upload_logs", action="store_true", help="Also upload job log if exists")
-    p.add_argument("--fail_on_s3_error", action="store_true", help="If upload fails, exit non-zero")
+    # ✅ 새 구조에 필요한 필드
+    p.add_argument("--experiment_id", required=True)
+    p.add_argument("--step", default="rfdiffusion", choices=["rfdiffusion", "alphafold", "proteinMPNN"])
+    p.add_argument("--dt", default=_kst_today())
 
+    # ✅ S3 업로드 옵션
+    p.add_argument("--s3_bucket", default=_get_s3_bucket_default())
+    p.add_argument("--s3_base", default=_get_s3_base_default())
+    p.add_argument("--s3_upload_logs", action="store_true")
+    p.add_argument("--fail_on_s3_error", action="store_true")
+
+    # (옵션) 이후 확장용: MPNN/AF 세부파라미터를 CLI로 받게 하고 싶으면 여기에 추가하면 됨
     return p.parse_args()
 
 
@@ -110,53 +107,113 @@ def run_cmd(cmd, env=None):
 def main():
     args = parse_args()
 
+    # ✅ 팀장님 지시: job name = experiment_id
+    args.name = args.experiment_id.strip()
+
     outputs_dir = Path(args.outputs_dir)
     outputs_dir.mkdir(parents=True, exist_ok=True)
 
+    # 공통 env
     env = os.environ.copy()
     env.setdefault("DGLBACKEND", "pytorch")
     env.setdefault("DGL_DISABLE_GRAPHBOLT", "1")
 
-    contig_str = str(args.contigs).strip()
-    contig_override = f"contigmap.contigs=[{contig_str!r}]"
+    # -----------------------
+    # 1) step 분기 실행
+    # -----------------------
+    step = args.step
 
-    py = pick_python()
+    if step == "rfdiffusion":
+        contig_str = str(args.contigs).strip()
+        contig_override = f"contigmap.contigs=[{contig_str!r}]"
 
-    cmd = [
-        py,
-        args.rfdiffusion_entry,
-        f"inference.output_prefix={outputs_dir / args.name}",
-        f"inference.num_designs={args.iterations}",
-        contig_override,
-    ]
+        py = pick_python()
+        cmd = [
+            py,
+            args.rfdiffusion_entry,
+            f"inference.output_prefix={outputs_dir / args.name}",
+            f"inference.num_designs={int(args.iterations)}",
+            contig_override,
+        ]
+        if args.cautious:
+            cmd.append("inference.cautious=True")
 
-    if args.cautious:
-        cmd.append("inference.cautious=True")
+        run_cmd(cmd, env=env)
 
-    # 1) RFdiffusion 실행
-    run_cmd(cmd, env=env)
+        produced = [
+            outputs_dir / f"{args.name}_0.pdb",
+            outputs_dir / f"{args.name}_0.trb",
+        ]
 
+    elif step == "proteinMPNN":
+        # iterations를 num_seqs로 매핑 (테스트하기 가장 편함)
+        from steps.proteinmpnn_step import MPNNStepConfig, run_mpnn_only
+
+        cfg = MPNNStepConfig(
+            experiment_id=args.experiment_id.strip(),
+            outputs_dir=outputs_dir,
+            contigs=str(args.contigs).strip(),
+            num_seqs=int(args.iterations),
+            mpnn_sampling_temp=0.1,
+            rm_aa="C",
+        )
+        result = run_mpnn_only(cfg)
+        print("[proteinMPNN] result:", result)
+
+        produced = [
+            outputs_dir / f"{args.name}_mpnn.fasta",
+            outputs_dir / f"{args.name}_mpnn_results.csv",
+        ]
+
+    elif step == "alphafold":
+        # iterations를 num_recycles로 매핑 (1이면 빠름)
+        from steps.alphafold_step import AlphaFoldStepConfig, run_alphafold_only
+
+        cfg = AlphaFoldStepConfig(
+            experiment_id=args.experiment_id.strip(),
+            outputs_dir=outputs_dir,
+            num_recycles=int(args.iterations),
+            use_multimer=False,
+            initial_guess=False,
+        )
+        result = run_alphafold_only(cfg)
+        print("[alphafold] result:", result)
+
+        produced = [
+            outputs_dir / f"{args.name}_af_best.pdb",
+            outputs_dir / f"{args.name}_af_results.csv",
+        ]
+
+    else:
+        raise SystemExit(f"Unknown step: {step}")
+
+    # -----------------------
     # 2) 생성물 확인
-    produced = [
-        outputs_dir / f"{args.name}_0.pdb",
-        outputs_dir / f"{args.name}_0.trb",
-    ]
-
-    print("[main.py] produced:")
-    for p in produced:
-        if p.exists():
-            print(" -", p, f"({p.stat().st_size} bytes)")
+    # -----------------------
+    print(f"[main.py] step={step} produced:")
+    for pth in produced:
+        if pth.exists():
+            print(" -", pth, f"({pth.stat().st_size} bytes)")
         else:
-            print(" -", p, "(missing)")
+            print(" -", pth, "(missing)")
 
-    # 3) (옵션) S3 업로드
+    # -----------------------
+    # 3) S3 업로드 (옵션)
+    # -----------------------
     bucket = (args.s3_bucket or "").strip()
     if not bucket:
         print("[s3] S3_BUCKET/AWS_S3_BUCKET not set; skip upload")
         return
 
-    prefix = (args.s3_prefix or "rfdiffusion").strip().strip("/")
-    print(f"[s3] bucket={bucket} prefix={prefix}")
+    prefix = build_s3_prefix(
+        base=args.s3_base,
+        dt=args.dt,
+        experiment_id=args.experiment_id,
+        step=args.step,
+    )
+
+    print(f"[s3] bucket={bucket}")
+    print(f"[s3] prefix={prefix}")
 
     try:
         from s3_uploader import upload_job_outputs
@@ -170,6 +227,7 @@ def main():
         uploaded = upload_job_outputs(
             outputs_dir=str(outputs_dir),
             job_name=args.name,
+            step=args.step,
             bucket=bucket,
             prefix=prefix,
             upload_logs=args.s3_upload_logs,

--- a/sim_tools/unified/src/s3_uploader.py
+++ b/sim_tools/unified/src/s3_uploader.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import boto3
+import zipfile
 
 
 def _region() -> str | None:
@@ -8,10 +9,6 @@ def _region() -> str | None:
 
 
 def upload_file_to_s3(local_path: str, bucket: str, key: str, content_type: str | None = None) -> str:
-    """
-    Upload a single file to S3 and return s3:// URL.
-    Requires AWS creds in env or shared config.
-    """
     s3 = boto3.client("s3", region_name=_region())
 
     extra_args = {}
@@ -26,40 +23,93 @@ def upload_file_to_s3(local_path: str, bucket: str, key: str, content_type: str 
     return f"s3://{bucket}/{key}"
 
 
+def _zip_dir(src_dir: Path, zip_path: Path) -> Path | None:
+    if not src_dir.exists() or not src_dir.is_dir():
+        return None
+
+    files = [p for p in src_dir.rglob("*") if p.is_file()]
+    if not files:
+        return None
+
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for f in files:
+            zf.write(f, arcname=str(f.relative_to(src_dir)))
+    return zip_path if zip_path.exists() and zip_path.stat().st_size > 0 else None
+
+
 def upload_job_outputs(
     outputs_dir: str,
     job_name: str,
+    step: str,
     bucket: str,
-    prefix: str = "rfdiffusion",
+    prefix: str,
     upload_logs: bool = False
 ) -> list[str]:
     """
-    Upload:
-      - {job_name}_0.pdb
-      - {job_name}_0.trb
-      - (optional) _logs/{job_name}.log
-    to:
-      s3://{bucket}/{prefix}/{job_name}/...
+    Upload to:
+      s3://{bucket}/{prefix}/(files...)
+
+    prefix 예:
+      simulations/dt=YYYY-MM-DD/pipeline=EXPERIMENT_ID/step=rfdiffusion
     """
     out = Path(outputs_dir)
-    candidates = [
-        out / f"{job_name}_0.pdb",
-        out / f"{job_name}_0.trb",
-    ]
+    step = (step or "").strip()
+
+    candidates: list[Path] = []
+
+    if step == "rfdiffusion":
+        candidates += [
+            out / f"{job_name}_0.pdb",
+            out / f"{job_name}_0.trb",
+        ]
+
+    elif step == "proteinMPNN":
+        candidates += [
+            out / f"{job_name}_mpnn.fasta",
+            out / f"{job_name}_mpnn_results.csv",
+        ]
+
+    elif step == "alphafold":
+        candidates += [
+            out / f"{job_name}_af_best.pdb",
+            out / f"{job_name}_af_results.csv",
+        ]
+        # all_pdb 폴더는 zip으로 올리기(있으면)
+        all_dir = out / f"{job_name}_af_all_pdb"
+        zip_path = out / f"{job_name}_af_all_pdb.zip"
+        z = _zip_dir(all_dir, zip_path)
+        if z is not None:
+            candidates.append(z)
+
+    else:
+        raise ValueError(f"Unknown step for upload: {step}")
 
     if upload_logs:
         candidates.append(out / "_logs" / f"{job_name}.log")
 
-    # ✅ prefix 정규화: 앞/뒤 '/' 제거해서 key 깨짐 방지
-    prefix = (prefix or "rfdiffusion").strip().strip("/")
+    prefix = (prefix or "").strip().strip("/")
+    if not prefix:
+        raise ValueError("prefix is required")
 
     uploaded: list[str] = []
     for p in candidates:
         if not p.exists() or p.stat().st_size <= 0:
             continue
 
-        key = f"{prefix}/{job_name}/{p.name}"
-        content_type = "chemical/x-pdb" if p.suffix == ".pdb" else "application/octet-stream"
+        key = f"{prefix}/{p.name}"
+
+        if p.suffix == ".pdb":
+            content_type = "chemical/x-pdb"
+        elif p.suffix in [".fasta", ".fa"]:
+            content_type = "text/plain"
+        elif p.suffix == ".csv":
+            content_type = "text/csv"
+        elif p.suffix == ".zip":
+            content_type = "application/zip"
+        else:
+            content_type = "application/octet-stream"
+
         uploaded.append(upload_file_to_s3(str(p), bucket, key, content_type=content_type))
 
     return uploaded

--- a/sim_tools/unified/src/steps/alphafold_step.py
+++ b/sim_tools/unified/src/steps/alphafold_step.py
@@ -1,0 +1,132 @@
+# /workspace/unified/src/steps/alphafold_step.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+
+from colabdesign.af import mk_af_model
+
+
+@dataclass
+class AlphaFoldStepConfig:
+    experiment_id: str
+    outputs_dir: Path
+    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑할 예정(기본 1)
+    use_multimer: bool = False
+    initial_guess: bool = False
+
+
+def _read_fasta_seqs(fasta_path: Path) -> List[str]:
+    if not fasta_path.exists():
+        raise FileNotFoundError(f"[alphafold] fasta not found: {fasta_path}")
+
+    seqs = []
+    buf = []
+    for line in fasta_path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith(">"):
+            if buf:
+                seqs.append("".join(buf))
+                buf = []
+            continue
+        buf.append(line)
+    if buf:
+        seqs.append("".join(buf))
+
+    # 아주 기본 정제
+    seqs = [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
+    return seqs
+
+
+def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
+    exp = cfg.experiment_id
+    out_dir = cfg.outputs_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    input_pdb = out_dir / f"{exp}_0.pdb"
+    if not input_pdb.exists():
+        raise FileNotFoundError(
+            f"[alphafold] input pdb not found: {input_pdb} "
+            f"(먼저 step=rfdiffusion을 같은 experiment_id로 실행해야 함)"
+        )
+
+    fasta_path = out_dir / f"{exp}_mpnn.fasta"
+    seqs = _read_fasta_seqs(fasta_path)
+    if not seqs:
+        raise RuntimeError(f"[alphafold] no sequences in fasta: {fasta_path}")
+
+    all_pdb_dir = out_dir / f"{exp}_af_all_pdb"
+    all_pdb_dir.mkdir(parents=True, exist_ok=True)
+
+    flags = {
+        "initial_guess": bool(cfg.initial_guess),
+        "best_metric": "rmsd",
+        "use_multimer": bool(cfg.use_multimer),
+        "model_names": ["model_1_multimer_v3" if cfg.use_multimer else "model_1_ptm"],
+    }
+
+    # 여기서는 가장 단순한 fixbb로 검증만 한다.
+    # (binder/partial/fixbb 프로토콜 분기는 필요하면 이후에 contigs 기반으로 확장 가능)
+    af_model = mk_af_model(protocol="fixbb", **flags)
+
+    # 입력 구조만 읽어서 “틀”을 잡고, 이후 seq만 바꿔가며 predict
+    af_model.prep_inputs(str(input_pdb), chain="A")
+
+    rows = []
+    best = {"idx": -1, "plddt": -1.0, "rmsd": 1e9, "path": None}
+
+    for i, seq in enumerate(seqs):
+        af_model.predict(seq=seq, num_recycles=int(cfg.num_recycles), verbose=False)
+
+        # aux log에서 대표 지표 추출
+        aux = af_model.aux.get("log", {})
+        plddt = float(aux.get("plddt", 0.0))
+        ptm = float(aux.get("ptm", 0.0)) if "ptm" in aux else None
+        pae = float(aux.get("pae", 0.0)) if "pae" in aux else None
+        rmsd = float(aux.get("rmsd", 0.0)) if "rmsd" in aux else None
+
+        pdb_path = all_pdb_dir / f"af_n{i}.pdb"
+        af_model.save_current_pdb(str(pdb_path))
+
+        rows.append(
+            {
+                "n": i,
+                "plddt": plddt,
+                "ptm": ptm,
+                "pae": pae,
+                "rmsd": rmsd,
+                "pdb": str(pdb_path),
+                "seq": seq,
+            }
+        )
+
+        # best 기준: plddt 우선, 동률이면 rmsd 작은 것
+        if (plddt > best["plddt"]) or (plddt == best["plddt"] and (rmsd or 1e9) < best["rmsd"]):
+            best = {"idx": i, "plddt": plddt, "rmsd": (rmsd or 1e9), "path": pdb_path}
+
+        # 내부 카운터 증가(원 코드 흐름과 비슷하게 유지)
+        af_model._k += 1
+
+    csv_path = out_dir / f"{exp}_af_results.csv"
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+
+    best_path = out_dir / f"{exp}_af_best.pdb"
+    if best["path"] is not None and Path(best["path"]).exists():
+        best_path.write_text(Path(best["path"]).read_text())
+
+    return {
+        "input_pdb": str(input_pdb),
+        "input_fasta": str(fasta_path),
+        "csv": str(csv_path),
+        "best_pdb": str(best_path),
+        "all_pdb_dir": str(all_pdb_dir),
+        "num_seqs": len(rows),
+        "best_idx": best["idx"],
+        "best_plddt": best["plddt"],
+        "best_rmsd": best["rmsd"],
+    }

--- a/sim_tools/unified/src/steps/alphafold_step.py
+++ b/sim_tools/unified/src/steps/alphafold_step.py
@@ -14,11 +14,9 @@ from colabdesign.af import mk_af_model
 class AlphaFoldStepConfig:
     experiment_id: str
     outputs_dir: Path
-    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑
+    num_recycles: int = 1
     use_multimer: bool = False
     initial_guess: bool = False
-    # ✅ AlphaFold params 위치 (env로 지정 가능)
-    alphafold_params_dir: str | None = None
 
 
 def _read_fasta_seqs(fasta_path: Path) -> List[str]:
@@ -40,75 +38,46 @@ def _read_fasta_seqs(fasta_path: Path) -> List[str]:
     if buf:
         seqs.append("".join(buf))
 
-    # 기본 정제
-    seqs = [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
-    return seqs
+    return [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
 
 
-def _resolve_af_params_dir(cfg: AlphaFoldStepConfig) -> Path:
-    # 1) cfg에 명시된 값
-    if cfg.alphafold_params_dir:
-        return Path(cfg.alphafold_params_dir)
+def _ensure_colabdesign_params_visible():
+    """
+    ColabDesign(af)에서 보통 ./params 아래의 params_model_*.npz 를 찾는 경우가 많아서,
+    실행 cwd(/workspace/unified) 기준으로 params 링크를 강제로 보장한다.
+    """
+    models_dir = Path(os.environ.get("MODELS_DIR", "/models"))
+    real_params_dir = Path(os.environ.get("AF_DIR", str(models_dir / "alphafold")))
 
-    # 2) env 우선순위: ALPHAFOLD_PARAMS_DIR -> AF_DIR -> MODELS_DIR/alphafold
-    env_dir = (
-        os.environ.get("ALPHAFOLD_PARAMS_DIR")
-        or os.environ.get("AF_DIR")
-        or ""
-    )
-    if env_dir.strip():
-        return Path(env_dir.strip())
-
-    models_dir = os.environ.get("MODELS_DIR", "/models")
-    return Path(models_dir) / "alphafold"
-
-
-def _assert_params_exist(params_dir: Path, use_multimer: bool):
-    # ColabDesign이 보통 찾는 파일들 (tar에서 풀린 파일명 기준)
-    required = []
-    if use_multimer:
-        required.append(params_dir / "params_model_1_multimer_v3.npz")
-    else:
-        required.append(params_dir / "params_model_1_ptm.npz")
-
-    missing = [str(p) for p in required if not p.exists()]
-    if missing:
-        # 디버깅 도움용: params_dir 내용 일부 보여주기
-        sample = sorted([p.name for p in params_dir.glob("params_model_*.npz")])[:10]
+    # 실제 params 존재 확인
+    need = real_params_dir / "params_model_1_ptm.npz"
+    if not need.exists():
+        sample = sorted([p.name for p in real_params_dir.glob("params_model_*.npz")])[:10]
         raise FileNotFoundError(
             "[alphafold] AlphaFold params not found.\n"
-            f" - params_dir={params_dir}\n"
-            f" - missing={missing}\n"
+            f" - expected: {need}\n"
+            f" - AF_DIR={real_params_dir}\n"
             f" - found_sample={sample}\n"
-            "Fix: ensure params are extracted into /models/alphafold (or set ALPHAFOLD_PARAMS_DIR/AF_DIR)."
         )
 
-
-def _mk_af_model_with_params(protocol: str, flags: dict, params_dir: Path):
-    """
-    ColabDesign 버전 차이 대비:
-    - mk_af_model이 data_dir/params_dir/weights_dir 등을 받을 수도 있음
-    - 못 받으면 모델 생성 후 속성(params_dir/data_dir 등)을 강제로 세팅
-    """
-    # 1) kwarg로 넘기기 (가능한 키를 순서대로 시도)
-    for key in ("params_dir", "data_dir", "weights_dir"):
-        try:
-            return mk_af_model(protocol=protocol, **flags, **{key: str(params_dir)})
-        except TypeError:
-            pass
-
-    # 2) kwarg가 전부 실패하면 생성 후 속성 세팅 시도
-    af_model = mk_af_model(protocol=protocol, **flags)
-
-    # 흔한 속성명들(버전별 상이)을 최대한 커버
-    for attr in ("params_dir", "data_dir", "weights_dir"):
-        if hasattr(af_model, attr):
-            try:
-                setattr(af_model, attr, str(params_dir))
-            except Exception:
-                pass
-
-    return af_model
+    # cwd 기준 ./params 만들기 (symlink)
+    cwd_params = Path.cwd() / "params"
+    try:
+        if cwd_params.is_symlink() or cwd_params.exists():
+            # 이미 있으면 그대로 둠 (다른 곳 가리키면 덮어씀)
+            cwd_params.unlink()
+        cwd_params.symlink_to(real_params_dir, target_is_directory=True)
+    except Exception:
+        # symlink 실패 환경 대비: 디렉토리 생성 + 파일 일부라도 복사하는 fallback(무겁긴 하지만)
+        cwd_params.mkdir(parents=True, exist_ok=True)
+        # 최소한 ptm/multimer 파일은 보장
+        for p in real_params_dir.glob("params_model_*.npz"):
+            dst = cwd_params / p.name
+            if not dst.exists():
+                try:
+                    dst.write_bytes(p.read_bytes())
+                except Exception:
+                    pass
 
 
 def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
@@ -128,9 +97,8 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     if not seqs:
         raise RuntimeError(f"[alphafold] no sequences in fasta: {fasta_path}")
 
-    # ✅ params dir 확정 + 존재 체크
-    params_dir = _resolve_af_params_dir(cfg)
-    _assert_params_exist(params_dir, use_multimer=bool(cfg.use_multimer))
+    # ✅ 핵심: ColabDesign이 params를 찾을 수 있게 ./params 보장
+    _ensure_colabdesign_params_visible()
 
     all_pdb_dir = out_dir / f"{exp}_af_all_pdb"
     all_pdb_dir.mkdir(parents=True, exist_ok=True)
@@ -144,10 +112,9 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
         "model_names": [model_name],
     }
 
-    # ✅ params_dir를 확실히 전달해서 mk_af_model이 모델 파라미터를 찾게 함
-    af_model = _mk_af_model_with_params(protocol="fixbb", flags=flags, params_dir=params_dir)
+    # ✅ params_dir 같은 kwarg 절대 금지 (너 로그에서 바로 죽는 거 확인됨)
+    af_model = mk_af_model(protocol="fixbb", **flags)
 
-    # 입력 구조만 읽어서 “틀” 잡기
     af_model.prep_inputs(str(input_pdb), chain="A")
 
     rows = []
@@ -166,21 +133,12 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
         af_model.save_current_pdb(str(pdb_path))
 
         rows.append(
-            {
-                "n": i,
-                "plddt": plddt,
-                "ptm": ptm,
-                "pae": pae,
-                "rmsd": rmsd,
-                "pdb": str(pdb_path),
-                "seq": seq,
-            }
+            {"n": i, "plddt": plddt, "ptm": ptm, "pae": pae, "rmsd": rmsd, "pdb": str(pdb_path), "seq": seq}
         )
 
         if (plddt > best["plddt"]) or (plddt == best["plddt"] and (rmsd or 1e9) < best["rmsd"]):
             best = {"idx": i, "plddt": plddt, "rmsd": (rmsd or 1e9), "path": pdb_path}
 
-        # ColabDesign 내부 카운터 증가(기존 흐름 유지)
         af_model._k += 1
 
     csv_path = out_dir / f"{exp}_af_results.csv"
@@ -193,7 +151,6 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     return {
         "input_pdb": str(input_pdb),
         "input_fasta": str(fasta_path),
-        "alphafold_params_dir": str(params_dir),
         "model_name": model_name,
         "csv": str(csv_path),
         "best_pdb": str(best_path),

--- a/sim_tools/unified/src/steps/alphafold_step.py
+++ b/sim_tools/unified/src/steps/alphafold_step.py
@@ -1,12 +1,12 @@
 # /workspace/unified/src/steps/alphafold_step.py
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
 
 import pandas as pd
-
 from colabdesign.af import mk_af_model
 
 
@@ -14,17 +14,19 @@ from colabdesign.af import mk_af_model
 class AlphaFoldStepConfig:
     experiment_id: str
     outputs_dir: Path
-    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑할 예정(기본 1)
+    num_recycles: int = 1        # iterations 값을 num_recycles로 매핑
     use_multimer: bool = False
     initial_guess: bool = False
+    # ✅ AlphaFold params 위치 (env로 지정 가능)
+    alphafold_params_dir: str | None = None
 
 
 def _read_fasta_seqs(fasta_path: Path) -> List[str]:
     if not fasta_path.exists():
         raise FileNotFoundError(f"[alphafold] fasta not found: {fasta_path}")
 
-    seqs = []
-    buf = []
+    seqs: List[str] = []
+    buf: List[str] = []
     for line in fasta_path.read_text().splitlines():
         line = line.strip()
         if not line:
@@ -38,9 +40,75 @@ def _read_fasta_seqs(fasta_path: Path) -> List[str]:
     if buf:
         seqs.append("".join(buf))
 
-    # 아주 기본 정제
+    # 기본 정제
     seqs = [s.replace("/", "").strip().upper() for s in seqs if s.strip()]
     return seqs
+
+
+def _resolve_af_params_dir(cfg: AlphaFoldStepConfig) -> Path:
+    # 1) cfg에 명시된 값
+    if cfg.alphafold_params_dir:
+        return Path(cfg.alphafold_params_dir)
+
+    # 2) env 우선순위: ALPHAFOLD_PARAMS_DIR -> AF_DIR -> MODELS_DIR/alphafold
+    env_dir = (
+        os.environ.get("ALPHAFOLD_PARAMS_DIR")
+        or os.environ.get("AF_DIR")
+        or ""
+    )
+    if env_dir.strip():
+        return Path(env_dir.strip())
+
+    models_dir = os.environ.get("MODELS_DIR", "/models")
+    return Path(models_dir) / "alphafold"
+
+
+def _assert_params_exist(params_dir: Path, use_multimer: bool):
+    # ColabDesign이 보통 찾는 파일들 (tar에서 풀린 파일명 기준)
+    required = []
+    if use_multimer:
+        required.append(params_dir / "params_model_1_multimer_v3.npz")
+    else:
+        required.append(params_dir / "params_model_1_ptm.npz")
+
+    missing = [str(p) for p in required if not p.exists()]
+    if missing:
+        # 디버깅 도움용: params_dir 내용 일부 보여주기
+        sample = sorted([p.name for p in params_dir.glob("params_model_*.npz")])[:10]
+        raise FileNotFoundError(
+            "[alphafold] AlphaFold params not found.\n"
+            f" - params_dir={params_dir}\n"
+            f" - missing={missing}\n"
+            f" - found_sample={sample}\n"
+            "Fix: ensure params are extracted into /models/alphafold (or set ALPHAFOLD_PARAMS_DIR/AF_DIR)."
+        )
+
+
+def _mk_af_model_with_params(protocol: str, flags: dict, params_dir: Path):
+    """
+    ColabDesign 버전 차이 대비:
+    - mk_af_model이 data_dir/params_dir/weights_dir 등을 받을 수도 있음
+    - 못 받으면 모델 생성 후 속성(params_dir/data_dir 등)을 강제로 세팅
+    """
+    # 1) kwarg로 넘기기 (가능한 키를 순서대로 시도)
+    for key in ("params_dir", "data_dir", "weights_dir"):
+        try:
+            return mk_af_model(protocol=protocol, **flags, **{key: str(params_dir)})
+        except TypeError:
+            pass
+
+    # 2) kwarg가 전부 실패하면 생성 후 속성 세팅 시도
+    af_model = mk_af_model(protocol=protocol, **flags)
+
+    # 흔한 속성명들(버전별 상이)을 최대한 커버
+    for attr in ("params_dir", "data_dir", "weights_dir"):
+        if hasattr(af_model, attr):
+            try:
+                setattr(af_model, attr, str(params_dir))
+            except Exception:
+                pass
+
+    return af_model
 
 
 def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
@@ -60,21 +128,26 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     if not seqs:
         raise RuntimeError(f"[alphafold] no sequences in fasta: {fasta_path}")
 
+    # ✅ params dir 확정 + 존재 체크
+    params_dir = _resolve_af_params_dir(cfg)
+    _assert_params_exist(params_dir, use_multimer=bool(cfg.use_multimer))
+
     all_pdb_dir = out_dir / f"{exp}_af_all_pdb"
     all_pdb_dir.mkdir(parents=True, exist_ok=True)
+
+    model_name = "model_1_multimer_v3" if cfg.use_multimer else "model_1_ptm"
 
     flags = {
         "initial_guess": bool(cfg.initial_guess),
         "best_metric": "rmsd",
         "use_multimer": bool(cfg.use_multimer),
-        "model_names": ["model_1_multimer_v3" if cfg.use_multimer else "model_1_ptm"],
+        "model_names": [model_name],
     }
 
-    # 여기서는 가장 단순한 fixbb로 검증만 한다.
-    # (binder/partial/fixbb 프로토콜 분기는 필요하면 이후에 contigs 기반으로 확장 가능)
-    af_model = mk_af_model(protocol="fixbb", **flags)
+    # ✅ params_dir를 확실히 전달해서 mk_af_model이 모델 파라미터를 찾게 함
+    af_model = _mk_af_model_with_params(protocol="fixbb", flags=flags, params_dir=params_dir)
 
-    # 입력 구조만 읽어서 “틀”을 잡고, 이후 seq만 바꿔가며 predict
+    # 입력 구조만 읽어서 “틀” 잡기
     af_model.prep_inputs(str(input_pdb), chain="A")
 
     rows = []
@@ -83,7 +156,6 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     for i, seq in enumerate(seqs):
         af_model.predict(seq=seq, num_recycles=int(cfg.num_recycles), verbose=False)
 
-        # aux log에서 대표 지표 추출
         aux = af_model.aux.get("log", {})
         plddt = float(aux.get("plddt", 0.0))
         ptm = float(aux.get("ptm", 0.0)) if "ptm" in aux else None
@@ -105,11 +177,10 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
             }
         )
 
-        # best 기준: plddt 우선, 동률이면 rmsd 작은 것
         if (plddt > best["plddt"]) or (plddt == best["plddt"] and (rmsd or 1e9) < best["rmsd"]):
             best = {"idx": i, "plddt": plddt, "rmsd": (rmsd or 1e9), "path": pdb_path}
 
-        # 내부 카운터 증가(원 코드 흐름과 비슷하게 유지)
+        # ColabDesign 내부 카운터 증가(기존 흐름 유지)
         af_model._k += 1
 
     csv_path = out_dir / f"{exp}_af_results.csv"
@@ -122,6 +193,8 @@ def run_alphafold_only(cfg: AlphaFoldStepConfig) -> dict:
     return {
         "input_pdb": str(input_pdb),
         "input_fasta": str(fasta_path),
+        "alphafold_params_dir": str(params_dir),
+        "model_name": model_name,
         "csv": str(csv_path),
         "best_pdb": str(best_path),
         "all_pdb_dir": str(all_pdb_dir),

--- a/sim_tools/unified/src/steps/proteinmpnn_step.py
+++ b/sim_tools/unified/src/steps/proteinmpnn_step.py
@@ -55,22 +55,47 @@ def _parse_contigs(contigs_raw: str) -> List[str]:
 
 def _get_info(contig: str) -> Tuple[List[int], List[bool]]:
     """
-    designability_test.py의 get_info 이식
-    fixed/free를 판단해서 protocol 결정에 사용
+    designability_test.py의 get_info 이식 + 보강
+    - "10" 처럼 하이픈 없는 숫자 세그먼트도 허용
+    - "A1-50/30" 같이 섞인 케이스도 허용
     """
-    F = []
+    F: List[int] = []
     free_chain = False
     fixed_chain = False
-    sub_contigs = [x.split("-") for x in contig.split("/")]
-    for (a, b) in sub_contigs:
-        if a[0].isalpha():
-            L = int(b) - int(a[1:]) + 1
-            F += [1] * L
-            fixed_chain = True
+
+    # contig 예시:
+    #  - "10"
+    #  - "1-10"
+    #  - "A1-50/30"
+    #  - "30/10"
+    for token in contig.split("/"):
+        token = token.strip()
+        if not token:
+            continue
+
+        if "-" in token:
+            a, b = token.split("-", 1)
+
+            # fixed segment: "A1-50"
+            if a and a[0].isalpha():
+                L = int(b) - int(a[1:]) + 1
+                F += [1] * L
+                fixed_chain = True
+            else:
+                # free segment: "1-10" 같은 케이스를 길이로 해석(10)
+                # (designability_test.py는 이런 형태를 거의 안 쓰지만 안전장치)
+                L = int(b)
+                F += [0] * L
+                free_chain = True
         else:
-            L = int(b)
+            # hyphen 없는 숫자: "10" -> free length 10
+            if token[0].isalpha():
+                # 혹시 "A10" 같은 이상 케이스 방어 (사실상 안 씀)
+                raise ValueError(f"invalid contig token without '-': {token}")
+            L = int(token)
             F += [0] * L
             free_chain = True
+
     return F, [fixed_chain, free_chain]
 
 

--- a/sim_tools/unified/src/steps/proteinmpnn_step.py
+++ b/sim_tools/unified/src/steps/proteinmpnn_step.py
@@ -1,0 +1,218 @@
+# /workspace/unified/src/steps/proteinmpnn_step.py
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from colabdesign.mpnn import mk_mpnn_model
+from colabdesign.af import mk_af_model
+from string import ascii_uppercase, ascii_lowercase
+
+alphabet_list = list(ascii_uppercase + ascii_lowercase)
+
+
+@dataclass
+class MPNNStepConfig:
+    experiment_id: str
+    outputs_dir: Path
+    contigs: str = "100"          # 현재 API/args에서 받는 contigs 그대로 사용
+    copies: int = 1               # 우선 1 고정 (필요하면 args로 확장)
+    rm_aa: str | None = "C"
+    num_seqs: int = 8             # iterations 값을 num_seqs로 매핑할 예정
+    mpnn_sampling_temp: float = 0.1
+
+
+def _parse_contigs(contigs_raw: str) -> List[str]:
+    """
+    ColabDesign 쪽 designability_test.py 로직을 최대한 비슷하게 따라감.
+    입력 예: "100" / "A1-50/30" / "50:50" 등
+    """
+    if not contigs_raw:
+        return ["100"]
+
+    contigs_raw = contigs_raw.strip()
+    # RFdiffusion에서 contigs가 "10"처럼 단일 숫자로 오는 케이스 대응
+    # 또는 "10:20"처럼 여러 개면 chain 분리 개념으로 봄
+    parts = contigs_raw.replace(" ", ":").replace(",", ":").split(":")
+    contigs = []
+    for contig_str in parts:
+        contig_str = contig_str.strip()
+        if not contig_str:
+            continue
+        segs = []
+        for x in contig_str.split("/"):
+            if x != "0":
+                segs.append(x)
+        if segs:
+            contigs.append("/".join(segs))
+    return contigs or ["100"]
+
+
+def _get_info(contig: str) -> Tuple[List[int], List[bool]]:
+    """
+    designability_test.py의 get_info 이식
+    fixed/free를 판단해서 protocol 결정에 사용
+    """
+    F = []
+    free_chain = False
+    fixed_chain = False
+    sub_contigs = [x.split("-") for x in contig.split("/")]
+    for (a, b) in sub_contigs:
+        if a[0].isalpha():
+            L = int(b) - int(a[1:]) + 1
+            F += [1] * L
+            fixed_chain = True
+        else:
+            L = int(b)
+            F += [0] * L
+            free_chain = True
+    return F, [fixed_chain, free_chain]
+
+
+def _infer_protocol_and_prep_flags(contigs: List[str], copies: int, rm_aa: str | None):
+    """
+    designability_test.py의 protocol 분기 + prep_flags 생성 로직
+    """
+    chains = alphabet_list[: len(contigs)]
+    info = [_get_info(x) for x in contigs]
+
+    fixed_pos = []
+    fixed_chains = []
+    free_chains = []
+    both_chains = []
+    for pos, (fixed_chain, free_chain) in info:
+        fixed_pos += pos
+        fixed_chains += [fixed_chain and not free_chain]
+        free_chains += [free_chain and not fixed_chain]
+        both_chains += [fixed_chain and free_chain]
+
+    flags = {
+        "initial_guess": False,
+        "best_metric": "rmsd",
+        "use_multimer": False,
+        "model_names": ["model_1_ptm"],
+    }
+
+    if sum(both_chains) == 0 and sum(fixed_chains) > 0 and sum(free_chains) > 0:
+        protocol = "binder"
+        target_chains = []
+        binder_chains = []
+        for n, x in enumerate(fixed_chains):
+            if x:
+                target_chains.append(chains[n])
+            else:
+                binder_chains.append(chains[n])
+        af_model = mk_af_model(protocol="binder", **flags)
+        prep_flags = {
+            "target_chain": ",".join(target_chains),
+            "binder_chain": ",".join(binder_chains),
+            "rm_aa": rm_aa,
+        }
+        fixed_pos_arr = None
+
+    elif sum(fixed_pos) > 0:
+        protocol = "partial"
+        af_model = mk_af_model(protocol="fixbb", use_templates=True, **flags)
+        rm_template = np.array(fixed_pos) == 0
+        prep_flags = {
+            "chain": ",".join(chains),
+            "rm_template": rm_template,
+            "rm_template_seq": rm_template,
+            "copies": copies,
+            "homooligomer": copies > 1,
+            "rm_aa": rm_aa,
+        }
+        fixed_pos_arr = np.array(fixed_pos)
+
+    else:
+        protocol = "fixbb"
+        af_model = mk_af_model(protocol="fixbb", **flags)
+        prep_flags = {
+            "chain": ",".join(chains),
+            "copies": copies,
+            "homooligomer": copies > 1,
+            "rm_aa": rm_aa,
+        }
+        fixed_pos_arr = None
+
+    return protocol, af_model, prep_flags, fixed_pos_arr
+
+
+def run_mpnn_only(cfg: MPNNStepConfig) -> dict:
+    """
+    MPNN-only:
+      - 입력 구조(pdb)로 af_model.prep_inputs만 써서 컨텍스트 구성
+      - MPNN sample만 수행
+      - AlphaFold predict는 절대 안 함
+    """
+    exp = cfg.experiment_id
+    out_dir = cfg.outputs_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    input_pdb = out_dir / f"{exp}_0.pdb"
+    if not input_pdb.exists():
+        raise FileNotFoundError(
+            f"[proteinMPNN] input pdb not found: {input_pdb} "
+            f"(먼저 step=rfdiffusion을 같은 experiment_id로 실행해야 함)"
+        )
+
+    contigs = _parse_contigs(cfg.contigs)
+    rm_aa = cfg.rm_aa if (cfg.rm_aa and cfg.rm_aa.strip()) else None
+
+    protocol, af_model, prep_flags, fixed_pos_arr = _infer_protocol_and_prep_flags(
+        contigs=contigs,
+        copies=cfg.copies,
+        rm_aa=rm_aa,
+    )
+
+    mpnn_model = mk_mpnn_model()
+
+    # designability_test.py에서 batch_size 로직 따라감
+    batch_size = 8
+    if cfg.num_seqs < batch_size:
+        batch_size = cfg.num_seqs
+
+    # 1) AF 입력 준비(구조 읽기만)
+    af_model.prep_inputs(str(input_pdb), **prep_flags)
+    if protocol == "partial" and fixed_pos_arr is not None:
+        p = np.where(fixed_pos_arr)[0]
+        af_model.opt["fix_pos"] = p[p < af_model._len]
+
+    # 2) MPNN에 AF 입력 전달 후 샘플링
+    mpnn_model.get_af_inputs(af_model)
+    out = mpnn_model.sample(
+        num=max(1, cfg.num_seqs // batch_size),
+        batch=batch_size,
+        temperature=float(cfg.mpnn_sampling_temp),
+    )
+
+    # out keys 예상: seq, score 등
+    seqs = out.get("seq", [])
+    scores = out.get("score", [])
+
+    # 3) 파일 저장
+    fasta_path = out_dir / f"{exp}_mpnn.fasta"
+    csv_path = out_dir / f"{exp}_mpnn_results.csv"
+
+    rows = []
+    with open(fasta_path, "w") as f:
+        for i, seq in enumerate(seqs):
+            seq_clean = re.sub(r"[^A-Z/]", "", seq).replace("/", "")
+            score = float(scores[i]) if i < len(scores) else float("nan")
+            f.write(f">mpnn_{i}|score={score:.6f}\n{seq_clean}\n")
+            rows.append({"n": i, "mpnn_score": score, "seq": seq_clean})
+
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+
+    return {
+        "input_pdb": str(input_pdb),
+        "fasta": str(fasta_path),
+        "csv": str(csv_path),
+        "num_seqs": len(rows),
+        "protocol": protocol,
+    }

--- a/sim_tools/unified/unified_shell_script.sh
+++ b/sim_tools/unified/unified_shell_script.sh
@@ -44,22 +44,17 @@ AF_PARAMS_TAR_URL="${AF_PARAMS_TAR_URL:-https://storage.googleapis.com/alphafold
 AF_PARAMS_TAR_NAME="${AF_PARAMS_TAR_NAME:-alphafold_params_2022-12-06.tar}"
 
 # -----------------------------
-# ✅ JAX GPU 정책(재발 방지)
-#  - 0: CPU jaxlib 허용
-#  - 1: CUDA jaxlib "반드시" 성공해야 함 (실패하면 install 단계에서 종료)
+# (옵션) JAX GPU indicates attempt
+#  - 0: CPU jaxlib 유지 (안전)
+#  - 1: CUDA jaxlib 설치 "시도" (실패해도 계속 진행)
 # -----------------------------
 ENABLE_JAX_CUDA="${ENABLE_JAX_CUDA:-0}"
-
-# -----------------------------
-# ✅ (권장) JAX CUDA wheel index
-# -----------------------------
-JAX_CUDA_WHEEL_INDEX="${JAX_CUDA_WHEEL_INDEX:-https://storage.googleapis.com/jax-releases/jax_cuda_releases.html}"
 
 ########################################
 # Utils
 ########################################
-log()  { echo "[ops] $*"; }
-die()  { echo "[ops][ERROR] $*" >&2; exit 1; }
+log() { echo "[ops] $*"; }
+die() { echo "[ops][ERROR] $*" >&2; exit 1; }
 warn() { echo "[ops][WARN] $*" >&2; }
 
 need_root() {
@@ -131,45 +126,36 @@ set_ld_library_path_for_torch() {
   export LD_LIBRARY_PATH="$(IFS=:; echo "${parts[*]}"):${LD_LIBRARY_PATH:-}"
 }
 
-# ✅ JAX는 torch venv의 nvidia libs로 꼬일 수 있으니 "제거"하되,
-#    시스템 CUDA 런타임 경로는 유지/추가(재발 방지).
+# ✅ NEW: JAX venv의 nvidia wheel libs를 LD_LIBRARY_PATH 앞에 붙여서
+#         jax-cuda plugin이 cuSPARSE 등을 확실히 찾게 함
 set_ld_library_path_for_jax() {
-  local cur="${LD_LIBRARY_PATH:-}"
+  local sp
+  sp="$(jax_site_packages || true)"
 
-  # 1) torch venv 아래 경로가 들어있으면 제거
-  if [[ -n "${cur}" ]]; then
-    cur="$(echo "$cur" | tr ':' '\n' | grep -vE '^/opt/venv_torch/' | paste -sd ':' -)"
+  if [[ -z "${sp}" ]]; then
+    warn "cannot resolve jax site-packages; LD_LIBRARY_PATH not set for jax"
+    return 0
   fi
 
-  # 2) 시스템 CUDA 후보 경로를 앞쪽에 추가
-  #    (이미 있으면 중복 없이 유지)
-  local candidates=(
-    "/usr/local/cuda/lib64"
-    "/usr/local/cuda/lib"
-    "/usr/lib/x86_64-linux-gnu"
-    "/usr/lib64"
-  )
-
+  local nvr="${sp}/nvidia"
   local parts=()
-  for d in "${candidates[@]}"; do
-    [[ -d "$d" ]] && parts+=("$d")
-  done
 
-  local prefix=""
-  if [[ "${#parts[@]}" -gt 0 ]]; then
-    prefix="$(IFS=:; echo "${parts[*]}")"
+  # jax-cuda12-plugin이 설치한 nvidia 패키지들의 lib 경로를 전부 수집
+  # 예: site-packages/nvidia/cusparse/lib, nvidia/cudnn/lib, nvidia/cublas/lib ...
+  if [[ -d "$nvr" ]]; then
+    while IFS= read -r d; do
+      [[ -d "$d" ]] && parts+=("$d")
+    done < <(find "$nvr" -maxdepth 3 -type d -name lib 2>/dev/null | sort)
   fi
 
-  if [[ -n "$prefix" && -n "$cur" ]]; then
-    export LD_LIBRARY_PATH="${prefix}:${cur}"
-  elif [[ -n "$prefix" ]]; then
-    export LD_LIBRARY_PATH="${prefix}"
-  else
-    # 시스템 경로를 못 찾으면 cur만 유지 (그래도 unset은 안 함)
-    export LD_LIBRARY_PATH="${cur}"
+  if [[ "${#parts[@]}" -eq 0 ]]; then
+    warn "no nvidia lib dirs found under: $nvr (LD_LIBRARY_PATH unchanged)"
+    return 0
   fi
 
-  log "LD_LIBRARY_PATH(jax)=${LD_LIBRARY_PATH:-<empty>}"
+  # ✅ venv_jax의 nvidia libs를 “맨 앞”에 둬서 시스템 CUDA보다 먼저 로드되게
+  export LD_LIBRARY_PATH="$(IFS=:; echo "${parts[*]}"):${LD_LIBRARY_PATH:-}"
+  log "LD_LIBRARY_PATH(jax)=${LD_LIBRARY_PATH}"
 }
 
 sanity_torch() {
@@ -199,27 +185,17 @@ except Exception as e:
 PY
 }
 
-# ✅ JAX GPU 강제 체크 함수 (재발 방지)
-sanity_jax_and_must_gpu_if_requested() {
+sanity_jax() {
   log "sanity(jax): python=$("$(venv_python_jax)" -V 2>&1 | tr -d '\r')"
   "$(venv_python_jax)" - <<'PY'
-import os, sys
-want_gpu = os.environ.get("ENABLE_JAX_CUDA","0") == "1"
 try:
   import jax
   dev = jax.devices()
-  has_gpu = any(getattr(d, "platform", "") == "gpu" for d in dev)
   print("[sanity][jax] version:", jax.__version__)
   print("[sanity][jax] devices:", dev)
-  print("[sanity][jax] has_gpu:", has_gpu)
-  if want_gpu and not has_gpu:
-    raise SystemExit("[sanity][jax] ENABLE_JAX_CUDA=1 but has_gpu=False (CUDA jaxlib not active)")
-except SystemExit as e:
-  print(str(e))
-  raise
+  print("[sanity][jax] has_gpu:", any(getattr(d, "platform", "") == "gpu" for d in dev))
 except Exception as e:
   print("[sanity][jax] import/devices failed:", repr(e))
-  raise
 PY
 }
 
@@ -270,6 +246,8 @@ refresh_s3_mapping() {
 # Helper: ensure ./params symlink
 ########################################
 ensure_unified_params_link() {
+  # ColabDesign이 종종 ./params 를 찾으므로
+  # /workspace/unified/params -> /models/alphafold (AF_DIR) 링크를 보장
   local link_path="${APP_DIR}/params"
   if [[ -L "$link_path" || -e "$link_path" ]]; then
     rm -rf "$link_path" || true
@@ -364,7 +342,8 @@ cmd_install() {
     --index-url https://download.pytorch.org/whl/cu121 \
     torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0
 
-  # ✅ cuDNN 재고정
+  # ✅ 중요: torch 2.2.0+cu121이 기대하는 cuDNN(=8.9.2.26)로 "재고정"
+  # - 이전에 9.x가 섞이면 libcudnn.so.8 링크가 없어져 ImportError가 날 수 있음
   "$(venv_python_torch)" -m pip install -U --no-deps "nvidia-cudnn-cu12==8.9.2.26" || true
 
   "$(venv_python_torch)" -m pip install \
@@ -427,40 +406,43 @@ cmd_install() {
 
   "$(venv_python_jax)" -m pip install -U pip setuptools wheel
   "$(venv_python_jax)" -m pip install "numpy<2"
+  # ✅ boto3/botocore (jax venv에도 필요)
   "$(venv_python_jax)" -m pip install -U boto3 botocore
+  # ✅ alphafold_step / proteinmpnn_step가 pandas를 쓰므로 JAX_VENV에 설치
   "$(venv_python_jax)" -m pip install -U pandas
 
   ########################################
-  # ✅ ColabDesign install (JAX_VENV)
+  # ✅ ColabDesign install (ProteinMPNN / AlphaFold)
   ########################################
   if [[ ! -d "$COLABDESIGN_DIR" ]]; then
     log "Cloning ColabDesign into $COLABDESIGN_DIR"
     git clone https://github.com/sokrypton/ColabDesign.git "$COLABDESIGN_DIR"
   fi
 
+  # ColabDesign는 JAX/Tensor 관련 deps를 건드릴 수 있어서 JAX venv에 설치
   log "installing ColabDesign (editable) (JAX_VENV)"
   "$(venv_python_jax)" -m pip install -e "$COLABDESIGN_DIR"
 
-  ########################################
-  # ✅ JAX CUDA: 재발 방지 설치 로직
-  ########################################
+  # (옵션) JAX CUDA 설치/고정
   if [[ "$ENABLE_JAX_CUDA" == "1" ]]; then
     log "JAX CUDA REQUIRED: removing CPU jax/jaxlib then installing CUDA-enabled jaxlib (JAX_VENV)"
-    # 1) 먼저 기존 jax/jaxlib 제거 (CPU 잔재가 남으면 계속 CPU로 뜨는 케이스 방지)
     "$(venv_python_jax)" -m pip uninstall -y jax jaxlib || true
-
-    # 2) CUDA jax 설치 (실패하면 바로 죽어야 재발 방지 됨)
-    #    (여기서 || true 절대 금지)
-    "$(venv_python_jax)" -m pip install -U "jax[cuda12]" -f "$JAX_CUDA_WHEEL_INDEX"
-
+    "$(venv_python_jax)" -m pip install -U "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
   else
-    log "JAX CPU allowed: installing CPU jax (JAX_VENV)"
+    # CPU jax 기본 확보
     "$(venv_python_jax)" -m pip install -U "jax" || true
   fi
 
   log "sanity check (TORCH_VENV)"
-  set_ld_library_path_for_torch
-  sanity_torch
+  "$(venv_python_torch)" - <<'PY'
+import sys
+print("python:", sys.version.split()[0])
+try:
+  import torch
+  print("torch:", torch.__version__, "cuda:", torch.version.cuda, "avail:", torch.cuda.is_available())
+except Exception as e:
+  print("torch import failed:", e)
+PY
 
   # ✅ cudnn .so 존재 체크 (python 버전 하드코딩 제거)
   TORCH_SP="$(torch_site_packages || true)"
@@ -477,10 +459,33 @@ cmd_install() {
   fi
 
   log "sanity check (JAX_VENV)"
-  # ✅ JAX 쪽은 시스템 CUDA 경로를 유지/추가한 상태로 체크
+  # ✅ install 시점에도 JAX용 LD_LIBRARY_PATH를 잡아주면 plugin 확인이 더 안정적
   set_ld_library_path_for_jax
-  export ENABLE_JAX_CUDA
-  sanity_jax_and_must_gpu_if_requested
+
+  "$(venv_python_jax)" - <<'PY'
+import sys
+print("python:", sys.version.split()[0])
+try:
+  import pandas as pd
+  print("pandas:", pd.__version__)
+except Exception as e:
+  print("pandas import failed:", e)
+
+try:
+  import colabdesign
+  print("colabdesign import: OK")
+except Exception as e:
+  print("colabdesign import failed:", e)
+
+try:
+  import jax
+  print("jax:", jax.__version__)
+  dev = jax.devices()
+  print("jax devices:", dev)
+  print("has_gpu:", any(getattr(d, "platform", "") == "gpu" for d in dev))
+except Exception as e:
+  print("jax import/devices failed:", e)
+PY
 
   log "install done"
 }
@@ -652,26 +657,31 @@ cmd_run() {
   cmd_download_params
   ensure_unified_params_link
 
-  # ✅ step별 PYTHONPATH 분리 (재발 방지)
+  # ✅ step별 PYTHONPATH 분리 (재발 방지 핵심)
+  # 기본은 src만
   export PYTHONPATH="$SCRIPT_DIR/src:${PYTHONPATH:-}"
 
+  # ✅ 핵심: step별 python 선택 + LD_LIBRARY_PATH 처리
   local py
   if [[ "$step" == "alphafold" || "$step" == "proteinMPNN" ]]; then
     py="$(venv_python_jax)"
 
-    # ✅ torch venv nvidia libs는 제거, 시스템 CUDA 경로는 유지/추가
+    # ✅ 핵심 수정: JAX step에서는 JAX venv의 nvidia libs를 LD_LIBRARY_PATH에 세팅
     set_ld_library_path_for_jax
-    export ENABLE_JAX_CUDA
+
     log "Using JAX_VENV python: $py"
     log "PYTHONPATH(jax)=$PYTHONPATH"
 
-    # ✅ 실행 전 반드시 체크 (ENABLE_JAX_CUDA=1이면 GPU 아니면 여기서 바로 죽음)
-    sanity_jax_and_must_gpu_if_requested
-
+    # 실행 전 sanity (로그로 증거 남김)
+    sanity_jax
+    if [[ "${ENABLE_JAX_CUDA:-0}" == "1" ]]; then
+      # sanity 로그에서 has_gpu가 True인지 확인
+      :
+    fi
   else
     py="$(venv_python_torch)"
 
-    # torch step은 nvidia libs path 세팅
+    # torch step은 nvidia libs path 세팅 (python 버전 하드코딩 제거)
     set_ld_library_path_for_torch
     log "Using TORCH_VENV python: $py"
     log "LD_LIBRARY_PATH set (torch/rfdiffusion)"
@@ -680,6 +690,7 @@ cmd_run() {
     export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
     log "PYTHONPATH(torch)=$PYTHONPATH"
 
+    # 실행 전 sanity (로그로 증거 남김)
     sanity_torch
   fi
 
@@ -712,6 +723,7 @@ cmd_serve() {
   ensure_dir "$APP_DIR"
   ensure_dir "$OUTPUTS_DIR"
 
+  # API 서버는 torch venv 기반
   "$(venv_python_torch)" -c "import uvicorn, fastapi" >/dev/null 2>&1 || \
     "$(venv_python_torch)" -m pip install -U uvicorn fastapi
 
@@ -733,7 +745,6 @@ cmd_serve() {
   env_kv+=("MODELS_DIR=$MODELS_DIR")
   env_kv+=("AF_DIR=$AF_DIR")
   env_kv+=("COLABDESIGN_DIR=$COLABDESIGN_DIR")
-  env_kv+=("ENABLE_JAX_CUDA=$ENABLE_JAX_CUDA")
 
   add_env_if_nonempty env_kv "S3_BUCKET" "${S3_BUCKET:-}"
   add_env_if_nonempty env_kv "S3_BASE" "${S3_BASE:-}"
@@ -809,7 +820,6 @@ AlphaFold/ColabDesign:
   AF_DIR=/models/alphafold
   COLABDESIGN_DIR=/workspace/colabdesign
   ENABLE_JAX_CUDA=0|1
-  JAX_CUDA_WHEEL_INDEX=$JAX_CUDA_WHEEL_INDEX
 
 S3 upload env (optional):
   S3_BUCKET=my-bucket

--- a/sim_tools/unified/unified_shell_script.sh
+++ b/sim_tools/unified/unified_shell_script.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 # Config (환경변수로 오버라이드 가능)
 ########################################
 PY_BIN="${PY_BIN:-python3}"
+
+# ✅ Split venvs
 TORCH_VENV="${TORCH_VENV:-/opt/venv_torch}"
+JAX_VENV="${JAX_VENV:-/opt/venv_jax}"
 
 APP_DIR="${APP_DIR:-/workspace/unified}"
 SCRIPT_DIR="${SCRIPT_DIR:-$APP_DIR}"
@@ -37,7 +40,7 @@ AF_PARAMS_TAR_URL="${AF_PARAMS_TAR_URL:-https://storage.googleapis.com/alphafold
 AF_PARAMS_TAR_NAME="${AF_PARAMS_TAR_NAME:-alphafold_params_2022-12-06.tar}"
 
 # -----------------------------
-# (옵션) JAX GPU 사용 시도 토글
+# (옵션) JAX GPU indicates attempt
 #  - 0: CPU jaxlib 유지 (안전)
 #  - 1: CUDA jaxlib 설치 "시도" (실패해도 계속 진행)
 # -----------------------------
@@ -56,7 +59,9 @@ need_root() {
 }
 
 ensure_dir() { mkdir -p "$1"; }
-venv_python() { echo "${TORCH_VENV}/bin/python"; }
+
+venv_python_torch() { echo "${TORCH_VENV}/bin/python"; }
+venv_python_jax()   { echo "${JAX_VENV}/bin/python"; }
 
 add_env_if_nonempty() {
   local -n _arr="$1"
@@ -116,7 +121,7 @@ ensure_unified_params_link() {
 }
 
 ########################################
-# Helper: parse --step from args (NEW)
+# Helper: parse --step from args
 ########################################
 extract_step_arg() {
   local step=""
@@ -148,6 +153,8 @@ cmd_up() {
   log "AF_DIR=$AF_DIR"
   log "COLABDESIGN_DIR=$COLABDESIGN_DIR"
   log "ENABLE_JAX_CUDA=$ENABLE_JAX_CUDA"
+  log "TORCH_VENV=$TORCH_VENV"
+  log "JAX_VENV=$JAX_VENV"
   log "S3_BUCKET=${S3_BUCKET:-<empty>}"
   log "S3_BASE=${S3_BASE:-simulations}"
   log "AWS_REGION=${AWS_REGION:-<empty>}"
@@ -172,6 +179,7 @@ cmd_install() {
   log "install start"
   log "PY_BIN=$PY_BIN"
   log "TORCH_VENV=$TORCH_VENV"
+  log "JAX_VENV=$JAX_VENV"
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
   log "COLABDESIGN_DIR=$COLABDESIGN_DIR"
   log "ENABLE_JAX_CUDA=$ENABLE_JAX_CUDA"
@@ -184,30 +192,31 @@ cmd_install() {
     build-essential pkg-config ca-certificates curl git unzip wget \
     python3-venv python3-dev
 
-  if [[ ! -x "$(venv_python)" ]]; then
-    log "creating venv at $TORCH_VENV"
+  # ---------- torch venv ----------
+  if [[ ! -x "$(venv_python_torch)" ]]; then
+    log "creating TORCH venv at $TORCH_VENV"
     $PY_BIN -m venv "$TORCH_VENV"
   fi
 
-  "$(venv_python)" -m pip install -U pip setuptools wheel
-  "$(venv_python)" -m pip install "numpy<2"
+  "$(venv_python_torch)" -m pip install -U pip setuptools wheel
+  "$(venv_python_torch)" -m pip install "numpy<2"
 
   # PyTorch CUDA (RFdiffusion)
-  "$(venv_python)" -m pip install \
+  "$(venv_python_torch)" -m pip install \
     --index-url https://download.pytorch.org/whl/cu121 \
     torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0
 
-  "$(venv_python)" -m pip install \
+  "$(venv_python_torch)" -m pip install \
     -f https://data.dgl.ai/wheels/torch-2.2/cu121/repo.html \
     dgl
 
-  "$(venv_python)" -m pip install -U opt_einsum pyrsistent e3nn
+  "$(venv_python_torch)" -m pip install -U opt_einsum pyrsistent e3nn
 
-  # API 서버용 패키지 포함
-  "$(venv_python)" -m pip install -U fastapi uvicorn
+  # API 서버용 패키지 포함 (torch venv에서 띄움)
+  "$(venv_python_torch)" -m pip install -U fastapi uvicorn
 
   # S3 업로드용
-  "$(venv_python)" -m pip install -U boto3 botocore
+  "$(venv_python_torch)" -m pip install -U boto3 botocore
 
   # RFdiffusion clone + install
   if [[ ! -d "$RFDIFFUSION_DIR" ]]; then
@@ -215,22 +224,22 @@ cmd_install() {
     git clone https://github.com/RosettaCommons/RFdiffusion.git "$RFDIFFUSION_DIR"
   fi
 
-  log "installing se3-transformer"
-  if "$(venv_python)" -c "import se3_transformer" >/dev/null 2>&1; then
+  log "installing se3-transformer (TORCH_VENV)"
+  if "$(venv_python_torch)" -c "import se3_transformer" >/dev/null 2>&1; then
     log "se3_transformer already importable. Skipping."
   else
-    "$(venv_python)" -m pip install -U opt_einsum
+    "$(venv_python_torch)" -m pip install -U opt_einsum
 
-    "$(venv_python)" -m pip install -U \
+    "$(venv_python_torch)" -m pip install -U \
       "git+https://github.com/NVIDIA/DeepLearningExamples.git#subdirectory=DGLPyTorch/DrugDiscovery/SE3Transformer" \
     || true
 
-    if ! "$(venv_python)" -c "import se3_transformer" >/dev/null 2>&1; then
+    if ! "$(venv_python_torch)" -c "import se3_transformer" >/dev/null 2>&1; then
       if [[ -d "$RFDIFFUSION_DIR/env/SE3Transformer" ]]; then
         log "fallback: installing SE3Transformer from $RFDIFFUSION_DIR/env/SE3Transformer"
         pushd "$RFDIFFUSION_DIR/env/SE3Transformer" >/dev/null
-        [[ -f requirements.txt ]] && "$(venv_python)" -m pip install -r requirements.txt
-        "$(venv_python)" -m pip install .
+        [[ -f requirements.txt ]] && "$(venv_python_torch)" -m pip install -r requirements.txt
+        "$(venv_python_torch)" -m pip install .
         popd >/dev/null
       else
         die "cannot install se3-transformer (no fallback dir found)"
@@ -238,16 +247,25 @@ cmd_install() {
     fi
   fi
 
-  log "installing RFdiffusion requirements (if present)"
-  [[ -f "$RFDIFFUSION_DIR/requirements.txt" ]] && "$(venv_python)" -m pip install -r "$RFDIFFUSION_DIR/requirements.txt" || true
-  [[ -f "$RFDIFFUSION_DIR/env/requirements.txt" ]] && "$(venv_python)" -m pip install -r "$RFDIFFUSION_DIR/env/requirements.txt" || true
+  log "installing RFdiffusion requirements (if present) (TORCH_VENV)"
+  [[ -f "$RFDIFFUSION_DIR/requirements.txt" ]] && "$(venv_python_torch)" -m pip install -r "$RFDIFFUSION_DIR/requirements.txt" || true
+  [[ -f "$RFDIFFUSION_DIR/env/requirements.txt" ]] && "$(venv_python_torch)" -m pip install -r "$RFDIFFUSION_DIR/env/requirements.txt" || true
 
-  "$(venv_python)" -m pip install -U omegaconf hydra-core
+  "$(venv_python_torch)" -m pip install -U omegaconf hydra-core
 
-  log "installing RFdiffusion (editable)"
+  log "installing RFdiffusion (editable) (TORCH_VENV)"
   pushd "$RFDIFFUSION_DIR" >/dev/null
-  "$(venv_python)" -m pip install -e .
+  "$(venv_python_torch)" -m pip install -e .
   popd >/dev/null
+
+  # ---------- jax venv ----------
+  if [[ ! -x "$(venv_python_jax)" ]]; then
+    log "creating JAX venv at $JAX_VENV"
+    $PY_BIN -m venv "$JAX_VENV"
+  fi
+
+  "$(venv_python_jax)" -m pip install -U pip setuptools wheel
+  "$(venv_python_jax)" -m pip install "numpy<2"
 
   ########################################
   # ✅ ColabDesign install (ProteinMPNN / AlphaFold)
@@ -256,17 +274,22 @@ cmd_install() {
     log "Cloning ColabDesign into $COLABDESIGN_DIR"
     git clone https://github.com/sokrypton/ColabDesign.git "$COLABDESIGN_DIR"
   fi
-  log "installing ColabDesign (editable)"
-  "$(venv_python)" -m pip install -e "$COLABDESIGN_DIR"
+
+  # ColabDesign는 JAX/Tensor 관련 deps를 건드릴 수 있어서 JAX venv에 설치
+  log "installing ColabDesign (editable) (JAX_VENV)"
+  "$(venv_python_jax)" -m pip install -e "$COLABDESIGN_DIR"
 
   # (옵션) JAX CUDA 설치 시도 (best-effort)
   if [[ "$ENABLE_JAX_CUDA" == "1" ]]; then
-    log "trying to install CUDA-enabled jaxlib (best-effort; may fail depending on CUDA/driver)"
-    "$(venv_python)" -m pip install -U "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || true
+    log "trying to install CUDA-enabled jaxlib (best-effort; may fail depending on CUDA/driver) (JAX_VENV)"
+    "$(venv_python_jax)" -m pip install -U "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || true
+  else
+    # CPU jax 기본 확보
+    "$(venv_python_jax)" -m pip install -U "jax" || true
   fi
 
-  log "sanity check"
-  "$(venv_python)" - <<'PY'
+  log "sanity check (TORCH_VENV)"
+  "$(venv_python_torch)" - <<'PY'
 import sys
 print("python:", sys.version.split()[0])
 try:
@@ -274,7 +297,12 @@ try:
   print("torch:", torch.__version__, "cuda:", torch.version.cuda, "avail:", torch.cuda.is_available())
 except Exception as e:
   print("torch import failed:", e)
+PY
 
+  log "sanity check (JAX_VENV)"
+  "$(venv_python_jax)" - <<'PY'
+import sys
+print("python:", sys.version.split()[0])
 try:
   import colabdesign
   print("colabdesign import: OK")
@@ -332,10 +360,8 @@ cmd_download_params() {
     download_http "$AF_PARAMS_TAR_URL" "$tar_path"
 
     log "Extracting AlphaFold params (tar --no-same-owner --no-same-permissions)"
-    # ✅ FIX: tar 실패를 성공 처리하지 않도록 || true 제거
     tar --no-same-owner --no-same-permissions -xf "$tar_path" -C "$AF_DIR"
 
-    # 최소 파일 존재 검사
     if [[ ! -s "${AF_DIR}/params_model_1_ptm.npz" ]]; then
       die "AlphaFold params extraction failed: ${AF_DIR}/params_model_1_ptm.npz not found"
     fi
@@ -435,7 +461,8 @@ cmd_run() {
   refresh_s3_mapping
 
   log "run start"
-  export MODELS_DIR OUTPUTS_DIR RFDIFFUSION_DIR TORCH_VENV
+  export MODELS_DIR OUTPUTS_DIR RFDIFFUSION_DIR
+  export TORCH_VENV JAX_VENV
   export AF_DIR COLABDESIGN_DIR
 
   log "MODELS_DIR=$MODELS_DIR"
@@ -443,25 +470,44 @@ cmd_run() {
   log "OUTPUTS_DIR=$OUTPUTS_DIR"
   log "SCRIPT_DIR=$SCRIPT_DIR"
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
+  log "TORCH_VENV=$TORCH_VENV"
+  log "JAX_VENV=$JAX_VENV"
 
   export DGLBACKEND="${DGLBACKEND:-pytorch}"
   export DGL_DISABLE_GRAPHBOLT="${DGL_DISABLE_GRAPHBOLT:-1}"
   log "DGLBACKEND=$DGLBACKEND"
   log "DGL_DISABLE_GRAPHBOLT=$DGL_DISABLE_GRAPHBOLT"
 
+  # ✅ unified/src 를 항상 잡고, RFdiffusion은 torch step에서만 직접 필요하지만 harmless
   export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
   log "PYTHONPATH=$PYTHONPATH"
 
-  # ✅ NEW: step별로 LD_LIBRARY_PATH 분기 (JAX가 꼬이는 케이스 방지)
+  # step 파싱
   local step
   step="$(extract_step_arg "$@")"
   log "detected step=${step:-<empty>}"
 
+  # params 준비는 공통
+  ensure_dir "$MODELS_DIR"
+  ensure_dir "$OUTPUTS_DIR"
+  cmd_download_params
+  ensure_unified_params_link
+
+  # ✅ 핵심: step별 python 선택 + LD_LIBRARY_PATH 처리
+  local py
   if [[ "$step" == "alphafold" || "$step" == "proteinMPNN" ]]; then
+    py="$(venv_python_jax)"
+
+    # jax/af step은 torch nvidia libs로 꼬이는 케이스가 있어서 방어
     unset LD_LIBRARY_PATH || true
+    log "Using JAX_VENV python: $py"
     log "LD_LIBRARY_PATH unset for step=$step (jax/af safety)"
   else
+    py="$(venv_python_torch)"
+
+    # torch step은 nvidia libs path 세팅
     export LD_LIBRARY_PATH="$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvtx/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvjitlink/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nccl/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/curand/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cufft/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_nvrtc/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_cupti/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cublas/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusparse/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cudnn/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusolver/lib:${LD_LIBRARY_PATH:-}"
+    log "Using TORCH_VENV python: $py"
     log "LD_LIBRARY_PATH set (torch/rfdiffusion)"
   fi
 
@@ -479,14 +525,8 @@ cmd_run() {
   log "S3_BASE=${S3_BASE:-<empty>}"
   log "AWS_REGION=${AWS_REGION:-<empty>}"
 
-  ensure_dir "$MODELS_DIR"
-  ensure_dir "$OUTPUTS_DIR"
-
-  cmd_download_params
-  ensure_unified_params_link
-
   cd "$APP_DIR"
-  "$(venv_python)" "$SCRIPT_DIR/src/main.py" "$@"
+  "$py" "$SCRIPT_DIR/src/main.py" "$@"
 }
 
 ########################################
@@ -500,8 +540,9 @@ cmd_serve() {
   ensure_dir "$APP_DIR"
   ensure_dir "$OUTPUTS_DIR"
 
-  "$(venv_python)" -c "import uvicorn, fastapi" >/dev/null 2>&1 || \
-    "$(venv_python)" -m pip install -U uvicorn fastapi
+  # API 서버는 torch venv 기반
+  "$(venv_python_torch)" -c "import uvicorn, fastapi" >/dev/null 2>&1 || \
+    "$(venv_python_torch)" -m pip install -U uvicorn fastapi
 
   if [[ -f "$UVICORN_PID" ]] && ps -p "$(cat "$UVICORN_PID")" >/dev/null 2>&1; then
     log "Already running: PID=$(cat "$UVICORN_PID")"
@@ -516,6 +557,7 @@ cmd_serve() {
   env_kv+=("OPS_SH=$SCRIPT_DIR/unified_shell_script.sh")
   env_kv+=("OUTPUTS_DIR=$OUTPUTS_DIR")
   env_kv+=("TORCH_VENV=$TORCH_VENV")
+  env_kv+=("JAX_VENV=$JAX_VENV")
   env_kv+=("PYTHONPATH=$RFDIFFUSION_DIR")
   env_kv+=("MODELS_DIR=$MODELS_DIR")
   env_kv+=("AF_DIR=$AF_DIR")
@@ -539,7 +581,7 @@ cmd_serve() {
   add_env_if_nonempty env_kv "AWS_SESSION_TOKEN" "${AWS_SESSION_TOKEN:-}"
 
   nohup env "${env_kv[@]}" \
-    "$(venv_python)" -m uvicorn api_server:app --host 0.0.0.0 --port "$PORT" \
+    "$(venv_python_torch)" -m uvicorn api_server:app --host 0.0.0.0 --port "$PORT" \
     > "$UVICORN_LOG" 2>&1 &
 
   echo $! > "$UVICORN_PID"
@@ -583,6 +625,7 @@ Usage:
 
 Env overrides:
   TORCH_VENV=/opt/venv_torch
+  JAX_VENV=/opt/venv_jax
   APP_DIR=/workspace/unified
   SCRIPT_DIR=/workspace/unified
   OUTPUTS_DIR=/workspace/unified/outputs

--- a/sim_tools/unified/unified_shell_script.sh
+++ b/sim_tools/unified/unified_shell_script.sh
@@ -24,12 +24,12 @@ UVICORN_PID="${UVICORN_PID:-${APP_DIR}/uvicorn_${PORT}.pid}"
 # (옵션) S3 업로드 관련 env
 # -----------------------------
 S3_BUCKET="${S3_BUCKET:-}"
-S3_PREFIX="${S3_PREFIX:-rfdiffusion}"
+S3_BASE="${S3_BASE:-simulations}"           # ✅ NEW: base root (default: simulations)
 AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 
 # ✅ AWS_S3_*도 지원 (RunPod Secret에서 AWS_S3_*만 넣어도 동작)
 AWS_S3_BUCKET="${AWS_S3_BUCKET:-}"
-AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"
+AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"   # ex) simulations  (or legacy values)
 
 ########################################
 # Utils
@@ -46,7 +46,7 @@ need_root() {
 ensure_dir() { mkdir -p "$1"; }
 venv_python() { echo "${TORCH_VENV}/bin/python"; }
 
-# ✅ 1번 방식: "비어있으면 env로 넘기지 않기" 헬퍼
+# ✅ "비어있으면 env로 넘기지 않기" 헬퍼
 add_env_if_nonempty() {
   local -n _arr="$1"
   local k="$2"
@@ -59,12 +59,10 @@ add_env_if_nonempty() {
 # ✅ RunPod에서 /proc/1(environ)에만 AWS/S3가 있고 현재 쉘에는 없을 때가 있음
 #    -> 그 경우 PID1의 AWS_/S3_만 안전하게 가져와서 export
 load_aws_env_from_pid1_if_missing() {
-  # 현재 쉘에 AWS_/S3_가 하나라도 있으면 아무것도 안 함
   if env | egrep -q '^(AWS_|S3_)'; then
     return 0
   fi
 
-  # /proc/1/environ 에서 AWS_/S3_만 골라 export
   if [[ -r /proc/1/environ ]]; then
     while IFS= read -r kv; do
       [[ "$kv" == *=* ]] || continue
@@ -73,7 +71,7 @@ load_aws_env_from_pid1_if_missing() {
   fi
 }
 
-# ✅ env 로드 후, AWS_S3_* -> S3_* 매핑 + prefix 정리 + region 보정
+# ✅ env 로드 후, AWS_S3_* -> S3_* 매핑 + base 정리 + region 보정
 refresh_s3_mapping() {
   # region 동기화
   AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
@@ -81,7 +79,6 @@ refresh_s3_mapping() {
     AWS_DEFAULT_REGION="$AWS_REGION"
   fi
 
-  # AWS_S3_* 값 확보
   AWS_S3_BUCKET="${AWS_S3_BUCKET:-}"
   AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"
 
@@ -90,13 +87,17 @@ refresh_s3_mapping() {
     S3_BUCKET="${AWS_S3_BUCKET}"
   fi
 
-  # S3_PREFIX가 비었거나 기본값(rfdiffusion)일 때만 AWS_S3_BASE_PATH로 덮어씀
-  if { [[ -z "${S3_PREFIX:-}" ]] || [[ "${S3_PREFIX}" == "rfdiffusion" ]]; } && [[ -n "${AWS_S3_BASE_PATH:-}" ]]; then
-    S3_PREFIX="${AWS_S3_BASE_PATH}"
+  # ✅ NEW: base root 매핑
+  # - S3_BASE가 비어있을 때만 AWS_S3_BASE_PATH로 채움
+  # - (주의) AWS_S3_BASE_PATH에 "simulations/sim_result" 같은 legacy 값이 들어오면
+  #         최신 구조에서는 base root로는 "simulations"만 쓰는 걸 권장.
+  if [[ -z "${S3_BASE:-}" && -n "${AWS_S3_BASE_PATH:-}" ]]; then
+    S3_BASE="${AWS_S3_BASE_PATH}"
   fi
 
-  # prefix 정리 (양끝 슬래시 제거) + 기본값 보장
-  S3_PREFIX="$(echo "${S3_PREFIX:-rfdiffusion}" | sed 's#^/*##; s#/*$##')"
+  # base 정리 (양끝 슬래시 제거) + 기본값 보장
+  S3_BASE="$(echo "${S3_BASE:-simulations}" | sed 's#^/*##; s#/*$##')"
+  [[ -n "${S3_BASE:-}" ]] || S3_BASE="simulations"
 }
 
 ########################################
@@ -115,7 +116,7 @@ cmd_up() {
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
   log "PORT=$PORT"
   log "S3_BUCKET=${S3_BUCKET:-<empty>}"
-  log "S3_PREFIX=$S3_PREFIX"
+  log "S3_BASE=${S3_BASE:-simulations}"
   log "AWS_REGION=${AWS_REGION:-<empty>}"
   log "AWS_S3_BUCKET=${AWS_S3_BUCKET:-<empty>}"
   log "AWS_S3_BASE_PATH=${AWS_S3_BASE_PATH:-<empty>}"
@@ -370,13 +371,14 @@ cmd_run() {
   log "DGLBACKEND=$DGLBACKEND"
   log "DGL_DISABLE_GRAPHBOLT=$DGL_DISABLE_GRAPHBOLT"
 
-  export PYTHONPATH="$RFDIFFUSION_DIR:${PYTHONPATH:-}"
+  # ✅ FIX: src 를 PYTHONPATH에 추가해서 `from steps...` import 가능하게
+  export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
   log "PYTHONPATH=$PYTHONPATH"
 
   export LD_LIBRARY_PATH="$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvtx/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvjitlink/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nccl/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/curand/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cufft/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_nvrtc/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_cupti/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cublas/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusparse/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cudnn/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusolver/lib:${LD_LIBRARY_PATH:-}"
   log "LD_LIBRARY_PATH set"
 
-  # ✅ 1번 방식: 비어있으면 export 자체를 하지 않음 (빈 값으로 덮어쓰기 방지)
+  # ✅ 비어있으면 export 자체를 하지 않음 (빈 값으로 덮어쓰기 방지)
   if [[ -n "${AWS_REGION:-}" ]]; then
     export AWS_REGION
     export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$AWS_REGION}"
@@ -385,10 +387,10 @@ cmd_run() {
   [[ -n "${AWS_S3_BASE_PATH:-}" ]] && export AWS_S3_BASE_PATH
 
   [[ -n "${S3_BUCKET:-}" ]] && export S3_BUCKET
-  [[ -n "${S3_PREFIX:-}" ]] && export S3_PREFIX
+  [[ -n "${S3_BASE:-}" ]] && export S3_BASE
 
   log "S3_BUCKET=${S3_BUCKET:-<empty>}"
-  log "S3_PREFIX=${S3_PREFIX:-<empty>}"
+  log "S3_BASE=${S3_BASE:-<empty>}"
   log "AWS_REGION=${AWS_REGION:-<empty>}"
 
   ensure_dir "$MODELS_DIR"
@@ -419,19 +421,19 @@ cmd_serve() {
 
   cd "$APP_DIR"
 
-  # ✅ 1번 방법 핵심:
-  #   env ... AWS_REGION="" 같은 "빈 값"을 넘기면 자식 프로세스에서 빈 값으로 덮어써짐.
-  #   따라서 "값이 있을 때만" env로 넘기도록 구성.
+  # ✅ "값이 있을 때만" env로 넘기기
   local env_kv=()
   env_kv+=("SCRIPT_DIR=$SCRIPT_DIR")
   env_kv+=("OPS_SH=$SCRIPT_DIR/unified_shell_script.sh")
   env_kv+=("OUTPUTS_DIR=$OUTPUTS_DIR")
   env_kv+=("TORCH_VENV=$TORCH_VENV")
-  env_kv+=("PYTHONPATH=$RFDIFFUSION_DIR")
+
+  # ✅ FIX: API 서버도 src + rfdiffusion 둘 다 PYTHONPATH에 포함
+  env_kv+=("PYTHONPATH=$SCRIPT_DIR/src:$RFDIFFUSION_DIR")
 
   # S3/AWS는 값이 있을 때만 넘김 (빈 값 전달 금지)
   add_env_if_nonempty env_kv "S3_BUCKET" "${S3_BUCKET:-}"
-  add_env_if_nonempty env_kv "S3_PREFIX" "${S3_PREFIX:-}"
+  add_env_if_nonempty env_kv "S3_BASE" "${S3_BASE:-}"
 
   add_env_if_nonempty env_kv "AWS_REGION" "${AWS_REGION:-}"
   if [[ -n "${AWS_REGION:-}" ]]; then
@@ -517,14 +519,14 @@ Env overrides:
   PORT=8000
 
 S3 upload env (optional):
-  # Preferred (existing)
+  # Preferred
   S3_BUCKET=my-bucket
-  S3_PREFIX=rfdiffusion
+  S3_BASE=simulations
   AWS_REGION=ap-northeast-2
 
   # Also supported (AWS-style)
   AWS_S3_BUCKET=my-bucket
-  AWS_S3_BASE_PATH=simulations/sim_result
+  AWS_S3_BASE_PATH=simulations
   AWS_ACCESS_KEY_ID=...
   AWS_SECRET_ACCESS_KEY=...
 EOF

--- a/sim_tools/unified/unified_shell_script.sh
+++ b/sim_tools/unified/unified_shell_script.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# (옵션) 디버그: OPS_DEBUG=1 이면 bash trace 출력
+OPS_DEBUG="${OPS_DEBUG:-0}"
+[[ "$OPS_DEBUG" == "1" ]] && set -x
+
 ########################################
 # Config (환경변수로 오버라이드 가능)
 ########################################
@@ -51,6 +55,7 @@ ENABLE_JAX_CUDA="${ENABLE_JAX_CUDA:-0}"
 ########################################
 log() { echo "[ops] $*"; }
 die() { echo "[ops][ERROR] $*" >&2; exit 1; }
+warn() { echo "[ops][WARN] $*" >&2; }
 
 need_root() {
   if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
@@ -62,6 +67,105 @@ ensure_dir() { mkdir -p "$1"; }
 
 venv_python_torch() { echo "${TORCH_VENV}/bin/python"; }
 venv_python_jax()   { echo "${JAX_VENV}/bin/python"; }
+
+# -----------------------------
+# Runtime helpers (venv-safe)
+#  - python 버전(3.10 등) 하드코딩 제거
+#  - site-packages 기반으로 nvidia lib 경로 구성
+# -----------------------------
+torch_site_packages() {
+  "$(venv_python_torch)" - <<'PY'
+import site
+paths = site.getsitepackages()
+print(paths[0] if paths else "")
+PY
+}
+
+jax_site_packages() {
+  "$(venv_python_jax)" - <<'PY'
+import site
+paths = site.getsitepackages()
+print(paths[0] if paths else "")
+PY
+}
+
+set_ld_library_path_for_torch() {
+  local sp
+  sp="$(torch_site_packages || true)"
+
+  if [[ -z "${sp}" ]]; then
+    warn "cannot resolve torch site-packages; LD_LIBRARY_PATH not set"
+    return 0
+  fi
+
+  local nvr="${sp}/nvidia"
+  local parts=()
+
+  for d in \
+    "$nvr/nvtx/lib" \
+    "$nvr/nvjitlink/lib" \
+    "$nvr/nccl/lib" \
+    "$nvr/curand/lib" \
+    "$nvr/cufft/lib" \
+    "$nvr/cuda_runtime/lib" \
+    "$nvr/cuda_nvrtc/lib" \
+    "$nvr/cuda_cupti/lib" \
+    "$nvr/cublas/lib" \
+    "$nvr/cusparse/lib" \
+    "$nvr/cudnn/lib" \
+    "$nvr/cusolver/lib"
+  do
+    [[ -d "$d" ]] && parts+=("$d")
+  done
+
+  if [[ "${#parts[@]}" -eq 0 ]]; then
+    warn "no nvidia lib dirs found under: $nvr (LD_LIBRARY_PATH unchanged)"
+    return 0
+  fi
+
+  export LD_LIBRARY_PATH="$(IFS=:; echo "${parts[*]}"):${LD_LIBRARY_PATH:-}"
+}
+
+sanity_torch() {
+  log "sanity(torch): python=$("$(venv_python_torch)" -V 2>&1 | tr -d '\r')"
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    log "sanity(torch): nvidia-smi OK"
+    nvidia-smi -L || true
+  else
+    warn "sanity(torch): nvidia-smi not found"
+  fi
+
+  "$(venv_python_torch)" - <<'PY'
+try:
+  import torch
+  print("[sanity][torch] version:", torch.__version__)
+  print("[sanity][torch] cuda:", torch.version.cuda)
+  print("[sanity][torch] cuda_available:", torch.cuda.is_available())
+  if torch.cuda.is_available():
+    print("[sanity][torch] device:", torch.cuda.get_device_name(0))
+  try:
+    import torch.backends.cudnn as cudnn
+    print("[sanity][torch] cudnn_version:", cudnn.version())
+  except Exception as e:
+    print("[sanity][torch] cudnn check failed:", repr(e))
+except Exception as e:
+  print("[sanity][torch] import torch failed:", repr(e))
+PY
+}
+
+sanity_jax() {
+  log "sanity(jax): python=$("$(venv_python_jax)" -V 2>&1 | tr -d '\r')"
+  "$(venv_python_jax)" - <<'PY'
+try:
+  import jax
+  dev = jax.devices()
+  print("[sanity][jax] version:", jax.__version__)
+  print("[sanity][jax] devices:", dev)
+  print("[sanity][jax] has_gpu:", any(getattr(d, "platform", "") == "gpu" for d in dev))
+except Exception as e:
+  print("[sanity][jax] import/devices failed:", repr(e))
+PY
+}
 
 add_env_if_nonempty() {
   local -n _arr="$1"
@@ -206,6 +310,10 @@ cmd_install() {
     --index-url https://download.pytorch.org/whl/cu121 \
     torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0
 
+  # ✅ 중요: torch 2.2.0+cu121이 기대하는 cuDNN(=8.9.2.26)로 "재고정"
+  # - 이전에 9.x가 섞이면 libcudnn.so.8 링크가 없어져 ImportError가 날 수 있음
+  "$(venv_python_torch)" -m pip install -U --no-deps "nvidia-cudnn-cu12==8.9.2.26" || true
+
   "$(venv_python_torch)" -m pip install \
     -f https://data.dgl.ai/wheels/torch-2.2/cu121/repo.html \
     dgl
@@ -266,6 +374,10 @@ cmd_install() {
 
   "$(venv_python_jax)" -m pip install -U pip setuptools wheel
   "$(venv_python_jax)" -m pip install "numpy<2"
+  # ✅ 여기에 넣기 (가장 안전)
+  "$(venv_python_jax)" -m pip install -U boto3 botocore
+  # ✅ alphafold_step / proteinmpnn_step가 pandas를 쓰므로 JAX_VENV에 설치
+  "$(venv_python_jax)" -m pip install -U pandas
 
   ########################################
   # ✅ ColabDesign install (ProteinMPNN / AlphaFold)
@@ -299,10 +411,30 @@ except Exception as e:
   print("torch import failed:", e)
 PY
 
+  # ✅ cudnn .so 존재 체크 (python 버전 하드코딩 제거)
+  TORCH_SP="$(torch_site_packages || true)"
+  if [[ -z "${TORCH_SP}" ]]; then
+    warn "cannot resolve torch site-packages to check cudnn"
+  else
+    CUDNN_SO="${TORCH_SP}/nvidia/cudnn/lib/libcudnn.so.8"
+    if [[ ! -e "$CUDNN_SO" ]]; then
+      warn "libcudnn.so.8 not found: $CUDNN_SO"
+      warn "you may hit: ImportError: libcudnn.so.8"
+    else
+      log "cudnn OK: $(ls -l "$CUDNN_SO" | awk '{print $9, $5, $6, $7, $8}')"
+    fi
+  fi
+
   log "sanity check (JAX_VENV)"
   "$(venv_python_jax)" - <<'PY'
 import sys
 print("python:", sys.version.split()[0])
+try:
+  import pandas as pd
+  print("pandas:", pd.__version__)
+except Exception as e:
+  print("pandas import failed:", e)
+
 try:
   import colabdesign
   print("colabdesign import: OK")
@@ -478,10 +610,6 @@ cmd_run() {
   log "DGLBACKEND=$DGLBACKEND"
   log "DGL_DISABLE_GRAPHBOLT=$DGL_DISABLE_GRAPHBOLT"
 
-  # ✅ unified/src 를 항상 잡고, RFdiffusion은 torch step에서만 직접 필요하지만 harmless
-  export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
-  log "PYTHONPATH=$PYTHONPATH"
-
   # step 파싱
   local step
   step="$(extract_step_arg "$@")"
@@ -493,6 +621,10 @@ cmd_run() {
   cmd_download_params
   ensure_unified_params_link
 
+  # ✅ step별 PYTHONPATH 분리 (재발 방지 핵심)
+  # 기본은 src만
+  export PYTHONPATH="$SCRIPT_DIR/src:${PYTHONPATH:-}"
+
   # ✅ 핵심: step별 python 선택 + LD_LIBRARY_PATH 처리
   local py
   if [[ "$step" == "alphafold" || "$step" == "proteinMPNN" ]]; then
@@ -502,13 +634,27 @@ cmd_run() {
     unset LD_LIBRARY_PATH || true
     log "Using JAX_VENV python: $py"
     log "LD_LIBRARY_PATH unset for step=$step (jax/af safety)"
+    log "PYTHONPATH(jax)=$PYTHONPATH"
+
+    # 실행 전 sanity (로그로 증거 남김)
+    sanity_jax
+    if [[ "${ENABLE_JAX_CUDA:-0}" == "1" ]]; then
+      warn "ENABLE_JAX_CUDA=1 (requested). Check has_gpu in sanity log above."
+    fi
   else
     py="$(venv_python_torch)"
 
-    # torch step은 nvidia libs path 세팅
-    export LD_LIBRARY_PATH="$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvtx/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvjitlink/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nccl/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/curand/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cufft/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_nvrtc/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_cupti/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cublas/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusparse/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cudnn/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusolver/lib:${LD_LIBRARY_PATH:-}"
+    # torch step은 nvidia libs path 세팅 (python 버전 하드코딩 제거)
+    set_ld_library_path_for_torch
     log "Using TORCH_VENV python: $py"
     log "LD_LIBRARY_PATH set (torch/rfdiffusion)"
+
+    # torch step에서만 RFdiffusion path 추가
+    export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
+    log "PYTHONPATH(torch)=$PYTHONPATH"
+
+    # 실행 전 sanity (로그로 증거 남김)
+    sanity_torch
   fi
 
   if [[ -n "${AWS_REGION:-}" ]]; then
@@ -631,6 +777,7 @@ Env overrides:
   OUTPUTS_DIR=/workspace/unified/outputs
   MODELS_DIR=/models
   PORT=8000
+  OPS_DEBUG=0|1
 
 AlphaFold/ColabDesign:
   AF_DIR=/models/alphafold

--- a/sim_tools/unified/unified_shell_script.sh
+++ b/sim_tools/unified/unified_shell_script.sh
@@ -7,10 +7,8 @@ set -euo pipefail
 PY_BIN="${PY_BIN:-python3}"
 TORCH_VENV="${TORCH_VENV:-/opt/venv_torch}"
 
-# unified 폴더 위치 (스크립트가 있는 경로 기준으로 자동 추론 가능)
 APP_DIR="${APP_DIR:-/workspace/unified}"
 SCRIPT_DIR="${SCRIPT_DIR:-$APP_DIR}"
-
 RFDIFFUSION_DIR="${RFDIFFUSION_DIR:-/app/RFdiffusion}"
 
 MODELS_DIR="${MODELS_DIR:-/models}"
@@ -24,12 +22,26 @@ UVICORN_PID="${UVICORN_PID:-${APP_DIR}/uvicorn_${PORT}.pid}"
 # (옵션) S3 업로드 관련 env
 # -----------------------------
 S3_BUCKET="${S3_BUCKET:-}"
-S3_BASE="${S3_BASE:-simulations}"           # ✅ NEW: base root (default: simulations)
+S3_BASE="${S3_BASE:-simulations}"
 AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 
-# ✅ AWS_S3_*도 지원 (RunPod Secret에서 AWS_S3_*만 넣어도 동작)
 AWS_S3_BUCKET="${AWS_S3_BUCKET:-}"
-AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"   # ex) simulations  (or legacy values)
+AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"
+
+# -----------------------------
+# ColabDesign / AlphaFold params
+# -----------------------------
+COLABDESIGN_DIR="${COLABDESIGN_DIR:-/workspace/colabdesign}"
+AF_DIR="${AF_DIR:-${MODELS_DIR}/alphafold}"
+AF_PARAMS_TAR_URL="${AF_PARAMS_TAR_URL:-https://storage.googleapis.com/alphafold/alphafold_params_2022-12-06.tar}"
+AF_PARAMS_TAR_NAME="${AF_PARAMS_TAR_NAME:-alphafold_params_2022-12-06.tar}"
+
+# -----------------------------
+# (옵션) JAX GPU 사용 시도 토글
+#  - 0: CPU jaxlib 유지 (안전)
+#  - 1: CUDA jaxlib 설치 "시도" (실패해도 계속 진행)
+# -----------------------------
+ENABLE_JAX_CUDA="${ENABLE_JAX_CUDA:-0}"
 
 ########################################
 # Utils
@@ -46,7 +58,6 @@ need_root() {
 ensure_dir() { mkdir -p "$1"; }
 venv_python() { echo "${TORCH_VENV}/bin/python"; }
 
-# ✅ "비어있으면 env로 넘기지 않기" 헬퍼
 add_env_if_nonempty() {
   local -n _arr="$1"
   local k="$2"
@@ -56,8 +67,6 @@ add_env_if_nonempty() {
   fi
 }
 
-# ✅ RunPod에서 /proc/1(environ)에만 AWS/S3가 있고 현재 쉘에는 없을 때가 있음
-#    -> 그 경우 PID1의 AWS_/S3_만 안전하게 가져와서 export
 load_aws_env_from_pid1_if_missing() {
   if env | egrep -q '^(AWS_|S3_)'; then
     return 0
@@ -71,9 +80,7 @@ load_aws_env_from_pid1_if_missing() {
   fi
 }
 
-# ✅ env 로드 후, AWS_S3_* -> S3_* 매핑 + base 정리 + region 보정
 refresh_s3_mapping() {
-  # region 동기화
   AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
   if [[ -n "${AWS_REGION:-}" && -z "${AWS_DEFAULT_REGION:-}" ]]; then
     AWS_DEFAULT_REGION="$AWS_REGION"
@@ -82,22 +89,45 @@ refresh_s3_mapping() {
   AWS_S3_BUCKET="${AWS_S3_BUCKET:-}"
   AWS_S3_BASE_PATH="${AWS_S3_BASE_PATH:-}"
 
-  # AWS_S3_* -> S3_* 자동 매핑
   if [[ -z "${S3_BUCKET:-}" && -n "${AWS_S3_BUCKET:-}" ]]; then
     S3_BUCKET="${AWS_S3_BUCKET}"
   fi
 
-  # ✅ NEW: base root 매핑
-  # - S3_BASE가 비어있을 때만 AWS_S3_BASE_PATH로 채움
-  # - (주의) AWS_S3_BASE_PATH에 "simulations/sim_result" 같은 legacy 값이 들어오면
-  #         최신 구조에서는 base root로는 "simulations"만 쓰는 걸 권장.
   if [[ -z "${S3_BASE:-}" && -n "${AWS_S3_BASE_PATH:-}" ]]; then
     S3_BASE="${AWS_S3_BASE_PATH}"
   fi
 
-  # base 정리 (양끝 슬래시 제거) + 기본값 보장
   S3_BASE="$(echo "${S3_BASE:-simulations}" | sed 's#^/*##; s#/*$##')"
   [[ -n "${S3_BASE:-}" ]] || S3_BASE="simulations"
+}
+
+########################################
+# Helper: ensure ./params symlink
+########################################
+ensure_unified_params_link() {
+  # ColabDesign이 종종 ./params 를 찾으므로
+  # /workspace/unified/params -> /models/alphafold (AF_DIR) 링크를 보장
+  local link_path="${APP_DIR}/params"
+  if [[ -L "$link_path" || -e "$link_path" ]]; then
+    rm -rf "$link_path" || true
+  fi
+  ln -s "$AF_DIR" "$link_path"
+  log "params link ensured: ${link_path} -> ${AF_DIR}"
+}
+
+########################################
+# Helper: parse --step from args (NEW)
+########################################
+extract_step_arg() {
+  local step=""
+  local args=("$@")
+  for ((i=0; i<${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "--step" && $((i+1)) -lt ${#args[@]} ]]; then
+      step="${args[$((i+1))]}"
+      break
+    fi
+  done
+  echo "$step"
 }
 
 ########################################
@@ -115,11 +145,12 @@ cmd_up() {
   log "MODELS_DIR=$MODELS_DIR"
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
   log "PORT=$PORT"
+  log "AF_DIR=$AF_DIR"
+  log "COLABDESIGN_DIR=$COLABDESIGN_DIR"
+  log "ENABLE_JAX_CUDA=$ENABLE_JAX_CUDA"
   log "S3_BUCKET=${S3_BUCKET:-<empty>}"
   log "S3_BASE=${S3_BASE:-simulations}"
   log "AWS_REGION=${AWS_REGION:-<empty>}"
-  log "AWS_S3_BUCKET=${AWS_S3_BUCKET:-<empty>}"
-  log "AWS_S3_BASE_PATH=${AWS_S3_BASE_PATH:-<empty>}"
   log "========================================"
 
   cmd_install
@@ -142,6 +173,8 @@ cmd_install() {
   log "PY_BIN=$PY_BIN"
   log "TORCH_VENV=$TORCH_VENV"
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
+  log "COLABDESIGN_DIR=$COLABDESIGN_DIR"
+  log "ENABLE_JAX_CUDA=$ENABLE_JAX_CUDA"
 
   $PY_BIN --version
 
@@ -159,6 +192,7 @@ cmd_install() {
   "$(venv_python)" -m pip install -U pip setuptools wheel
   "$(venv_python)" -m pip install "numpy<2"
 
+  # PyTorch CUDA (RFdiffusion)
   "$(venv_python)" -m pip install \
     --index-url https://download.pytorch.org/whl/cu121 \
     torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0
@@ -172,9 +206,10 @@ cmd_install() {
   # API 서버용 패키지 포함
   "$(venv_python)" -m pip install -U fastapi uvicorn
 
-  # ✅ S3 업로드용
+  # S3 업로드용
   "$(venv_python)" -m pip install -U boto3 botocore
 
+  # RFdiffusion clone + install
   if [[ ! -d "$RFDIFFUSION_DIR" ]]; then
     log "Cloning RFdiffusion into $RFDIFFUSION_DIR"
     git clone https://github.com/RosettaCommons/RFdiffusion.git "$RFDIFFUSION_DIR"
@@ -203,16 +238,10 @@ cmd_install() {
     fi
   fi
 
-  # RFdiffusion deps
   log "installing RFdiffusion requirements (if present)"
-  if [[ -f "$RFDIFFUSION_DIR/requirements.txt" ]]; then
-    "$(venv_python)" -m pip install -r "$RFDIFFUSION_DIR/requirements.txt"
-  fi
-  if [[ -f "$RFDIFFUSION_DIR/env/requirements.txt" ]]; then
-    "$(venv_python)" -m pip install -r "$RFDIFFUSION_DIR/env/requirements.txt"
-  fi
+  [[ -f "$RFDIFFUSION_DIR/requirements.txt" ]] && "$(venv_python)" -m pip install -r "$RFDIFFUSION_DIR/requirements.txt" || true
+  [[ -f "$RFDIFFUSION_DIR/env/requirements.txt" ]] && "$(venv_python)" -m pip install -r "$RFDIFFUSION_DIR/env/requirements.txt" || true
 
-  # 안전장치
   "$(venv_python)" -m pip install -U omegaconf hydra-core
 
   log "installing RFdiffusion (editable)"
@@ -220,21 +249,46 @@ cmd_install() {
   "$(venv_python)" -m pip install -e .
   popd >/dev/null
 
+  ########################################
+  # ✅ ColabDesign install (ProteinMPNN / AlphaFold)
+  ########################################
+  if [[ ! -d "$COLABDESIGN_DIR" ]]; then
+    log "Cloning ColabDesign into $COLABDESIGN_DIR"
+    git clone https://github.com/sokrypton/ColabDesign.git "$COLABDESIGN_DIR"
+  fi
+  log "installing ColabDesign (editable)"
+  "$(venv_python)" -m pip install -e "$COLABDESIGN_DIR"
+
+  # (옵션) JAX CUDA 설치 시도 (best-effort)
+  if [[ "$ENABLE_JAX_CUDA" == "1" ]]; then
+    log "trying to install CUDA-enabled jaxlib (best-effort; may fail depending on CUDA/driver)"
+    "$(venv_python)" -m pip install -U "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || true
+  fi
+
   log "sanity check"
   "$(venv_python)" - <<'PY'
-import sys, numpy as np, torch, dgl, e3nn, pyrsistent, se3_transformer
-import omegaconf, hydra
-import boto3
+import sys
 print("python:", sys.version.split()[0])
-print("numpy :", np.__version__)
-print("torch :", torch.__version__, "cuda:", torch.version.cuda, "avail:", torch.cuda.is_available())
-print("dgl   :", dgl.__version__)
-print("e3nn  :", getattr(e3nn, "__version__", "unknown"))
-print("pyrsistent import: OK")
-print("se3_transformer import: OK")
-print("omegaconf:", getattr(omegaconf, "__version__", "unknown"))
-print("hydra:", getattr(hydra, "__version__", "unknown"))
-print("boto3:", getattr(boto3, "__version__", "unknown"))
+try:
+  import torch
+  print("torch:", torch.__version__, "cuda:", torch.version.cuda, "avail:", torch.cuda.is_available())
+except Exception as e:
+  print("torch import failed:", e)
+
+try:
+  import colabdesign
+  print("colabdesign import: OK")
+except Exception as e:
+  print("colabdesign import failed:", e)
+
+try:
+  import jax
+  print("jax:", jax.__version__)
+  dev = jax.devices()
+  print("jax devices:", dev)
+  print("has_gpu:", any(getattr(d, "platform", "") == "gpu" for d in dev))
+except Exception as e:
+  print("jax import/devices failed:", e)
 PY
 
   log "install done"
@@ -268,9 +322,31 @@ cmd_download_params() {
   log "download_params start"
   ensure_dir "$MODELS_DIR"
 
-  AF_DIR="${AF_DIR:-$MODELS_DIR/alphafold}"
+  ########################################
+  # ✅ AlphaFold params (ColabDesign용)
+  ########################################
   ensure_dir "$AF_DIR"
+  if [[ ! -s "${AF_DIR}/params_model_1_ptm.npz" ]]; then
+    log "AlphaFold params missing; downloading..."
+    local tar_path="${AF_DIR}/${AF_PARAMS_TAR_NAME}"
+    download_http "$AF_PARAMS_TAR_URL" "$tar_path"
 
+    log "Extracting AlphaFold params (tar --no-same-owner --no-same-permissions)"
+    # ✅ FIX: tar 실패를 성공 처리하지 않도록 || true 제거
+    tar --no-same-owner --no-same-permissions -xf "$tar_path" -C "$AF_DIR"
+
+    # 최소 파일 존재 검사
+    if [[ ! -s "${AF_DIR}/params_model_1_ptm.npz" ]]; then
+      die "AlphaFold params extraction failed: ${AF_DIR}/params_model_1_ptm.npz not found"
+    fi
+    log "AlphaFold params ready: ${AF_DIR}"
+  else
+    log "AlphaFold params OK (exists): ${AF_DIR}/params_model_1_ptm.npz"
+  fi
+
+  ########################################
+  # RFdiffusion checkpoints (기존 로직 유지)
+  ########################################
   RFD_MODELS_DIR="${RFD_MODELS_DIR:-$RFDIFFUSION_DIR/models}"
   ensure_dir "$RFD_MODELS_DIR"
 
@@ -278,7 +354,7 @@ cmd_download_params() {
   ensure_dir "$RFD_SOURCE_DIR"
 
   log "MODELS_DIR=$MODELS_DIR"
-  log "AF_DIR=$AF_DIR (AlphaFold params: keep existing logic)"
+  log "AF_DIR=$AF_DIR"
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
   log "RFD_MODELS_DIR=$RFD_MODELS_DIR"
   log "RFD_SOURCE_DIR=$RFD_SOURCE_DIR"
@@ -360,8 +436,10 @@ cmd_run() {
 
   log "run start"
   export MODELS_DIR OUTPUTS_DIR RFDIFFUSION_DIR TORCH_VENV
+  export AF_DIR COLABDESIGN_DIR
 
   log "MODELS_DIR=$MODELS_DIR"
+  log "AF_DIR=$AF_DIR"
   log "OUTPUTS_DIR=$OUTPUTS_DIR"
   log "SCRIPT_DIR=$SCRIPT_DIR"
   log "RFDIFFUSION_DIR=$RFDIFFUSION_DIR"
@@ -371,14 +449,22 @@ cmd_run() {
   log "DGLBACKEND=$DGLBACKEND"
   log "DGL_DISABLE_GRAPHBOLT=$DGL_DISABLE_GRAPHBOLT"
 
-  # ✅ FIX: src 를 PYTHONPATH에 추가해서 `from steps...` import 가능하게
   export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
   log "PYTHONPATH=$PYTHONPATH"
 
-  export LD_LIBRARY_PATH="$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvtx/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvjitlink/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nccl/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/curand/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cufft/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_nvrtc/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_cupti/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cublas/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusparse/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cudnn/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusolver/lib:${LD_LIBRARY_PATH:-}"
-  log "LD_LIBRARY_PATH set"
+  # ✅ NEW: step별로 LD_LIBRARY_PATH 분기 (JAX가 꼬이는 케이스 방지)
+  local step
+  step="$(extract_step_arg "$@")"
+  log "detected step=${step:-<empty>}"
 
-  # ✅ 비어있으면 export 자체를 하지 않음 (빈 값으로 덮어쓰기 방지)
+  if [[ "$step" == "alphafold" || "$step" == "proteinMPNN" ]]; then
+    unset LD_LIBRARY_PATH || true
+    log "LD_LIBRARY_PATH unset for step=$step (jax/af safety)"
+  else
+    export LD_LIBRARY_PATH="$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvtx/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nvjitlink/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/nccl/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/curand/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cufft/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_nvrtc/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cuda_cupti/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cublas/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusparse/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cudnn/lib:$TORCH_VENV/lib/python3.10/site-packages/nvidia/cusolver/lib:${LD_LIBRARY_PATH:-}"
+    log "LD_LIBRARY_PATH set (torch/rfdiffusion)"
+  fi
+
   if [[ -n "${AWS_REGION:-}" ]]; then
     export AWS_REGION
     export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$AWS_REGION}"
@@ -397,6 +483,9 @@ cmd_run() {
   ensure_dir "$OUTPUTS_DIR"
 
   cmd_download_params
+  ensure_unified_params_link
+
+  cd "$APP_DIR"
   "$(venv_python)" "$SCRIPT_DIR/src/main.py" "$@"
 }
 
@@ -420,18 +509,18 @@ cmd_serve() {
   fi
 
   cd "$APP_DIR"
+  ensure_unified_params_link
 
-  # ✅ "값이 있을 때만" env로 넘기기
   local env_kv=()
   env_kv+=("SCRIPT_DIR=$SCRIPT_DIR")
   env_kv+=("OPS_SH=$SCRIPT_DIR/unified_shell_script.sh")
   env_kv+=("OUTPUTS_DIR=$OUTPUTS_DIR")
   env_kv+=("TORCH_VENV=$TORCH_VENV")
+  env_kv+=("PYTHONPATH=$RFDIFFUSION_DIR")
+  env_kv+=("MODELS_DIR=$MODELS_DIR")
+  env_kv+=("AF_DIR=$AF_DIR")
+  env_kv+=("COLABDESIGN_DIR=$COLABDESIGN_DIR")
 
-  # ✅ FIX: API 서버도 src + rfdiffusion 둘 다 PYTHONPATH에 포함
-  env_kv+=("PYTHONPATH=$SCRIPT_DIR/src:$RFDIFFUSION_DIR")
-
-  # S3/AWS는 값이 있을 때만 넘김 (빈 값 전달 금지)
   add_env_if_nonempty env_kv "S3_BUCKET" "${S3_BUCKET:-}"
   add_env_if_nonempty env_kv "S3_BASE" "${S3_BASE:-}"
 
@@ -445,7 +534,6 @@ cmd_serve() {
   add_env_if_nonempty env_kv "AWS_S3_BUCKET" "${AWS_S3_BUCKET:-}"
   add_env_if_nonempty env_kv "AWS_S3_BASE_PATH" "${AWS_S3_BASE_PATH:-}"
 
-  # (옵션) creds도 같이 넘기고 싶으면 여기도 nonempty로 추가 가능
   add_env_if_nonempty env_kv "AWS_ACCESS_KEY_ID" "${AWS_ACCESS_KEY_ID:-}"
   add_env_if_nonempty env_kv "AWS_SECRET_ACCESS_KEY" "${AWS_SECRET_ACCESS_KEY:-}"
   add_env_if_nonempty env_kv "AWS_SESSION_TOKEN" "${AWS_SESSION_TOKEN:-}"
@@ -470,22 +558,9 @@ cmd_stop() {
     fi
     rm -f "$UVICORN_PID"
   fi
-
-  if command -v pgrep >/dev/null 2>&1; then
-    local pids
-    pids="$(pgrep -f "uvicorn api_server:app" || true)"
-    if [[ -n "$pids" ]]; then
-      log "Stopping uvicorn (pgrep): $pids"
-      kill $pids || true
-    fi
-  fi
-
   log "stop done"
 }
 
-########################################
-# 5) Logs
-########################################
 cmd_logs_api() { tail -f "$UVICORN_LOG"; }
 
 cmd_logs_job() {
@@ -494,13 +569,9 @@ cmd_logs_job() {
   tail -f "${OUTPUTS_DIR}/_logs/${name}.log"
 }
 
-########################################
-# Help / Router
-########################################
 usage() {
   cat <<EOF
 Usage:
-  ./unified_shell_script.sh
   ./unified_shell_script.sh up
   ./unified_shell_script.sh install
   ./unified_shell_script.sh download-params
@@ -518,17 +589,15 @@ Env overrides:
   MODELS_DIR=/models
   PORT=8000
 
+AlphaFold/ColabDesign:
+  AF_DIR=/models/alphafold
+  COLABDESIGN_DIR=/workspace/colabdesign
+  ENABLE_JAX_CUDA=0|1
+
 S3 upload env (optional):
-  # Preferred
   S3_BUCKET=my-bucket
   S3_BASE=simulations
   AWS_REGION=ap-northeast-2
-
-  # Also supported (AWS-style)
-  AWS_S3_BUCKET=my-bucket
-  AWS_S3_BASE_PATH=simulations
-  AWS_ACCESS_KEY_ID=...
-  AWS_SECRET_ACCESS_KEY=...
 EOF
 }
 

--- a/sim_tools/unified/unified_shell_script.sh
+++ b/sim_tools/unified/unified_shell_script.sh
@@ -44,17 +44,22 @@ AF_PARAMS_TAR_URL="${AF_PARAMS_TAR_URL:-https://storage.googleapis.com/alphafold
 AF_PARAMS_TAR_NAME="${AF_PARAMS_TAR_NAME:-alphafold_params_2022-12-06.tar}"
 
 # -----------------------------
-# (옵션) JAX GPU indicates attempt
-#  - 0: CPU jaxlib 유지 (안전)
-#  - 1: CUDA jaxlib 설치 "시도" (실패해도 계속 진행)
+# ✅ JAX GPU 정책(재발 방지)
+#  - 0: CPU jaxlib 허용
+#  - 1: CUDA jaxlib "반드시" 성공해야 함 (실패하면 install 단계에서 종료)
 # -----------------------------
 ENABLE_JAX_CUDA="${ENABLE_JAX_CUDA:-0}"
+
+# -----------------------------
+# ✅ (권장) JAX CUDA wheel index
+# -----------------------------
+JAX_CUDA_WHEEL_INDEX="${JAX_CUDA_WHEEL_INDEX:-https://storage.googleapis.com/jax-releases/jax_cuda_releases.html}"
 
 ########################################
 # Utils
 ########################################
-log() { echo "[ops] $*"; }
-die() { echo "[ops][ERROR] $*" >&2; exit 1; }
+log()  { echo "[ops] $*"; }
+die()  { echo "[ops][ERROR] $*" >&2; exit 1; }
 warn() { echo "[ops][WARN] $*" >&2; }
 
 need_root() {
@@ -126,6 +131,47 @@ set_ld_library_path_for_torch() {
   export LD_LIBRARY_PATH="$(IFS=:; echo "${parts[*]}"):${LD_LIBRARY_PATH:-}"
 }
 
+# ✅ JAX는 torch venv의 nvidia libs로 꼬일 수 있으니 "제거"하되,
+#    시스템 CUDA 런타임 경로는 유지/추가(재발 방지).
+set_ld_library_path_for_jax() {
+  local cur="${LD_LIBRARY_PATH:-}"
+
+  # 1) torch venv 아래 경로가 들어있으면 제거
+  if [[ -n "${cur}" ]]; then
+    cur="$(echo "$cur" | tr ':' '\n' | grep -vE '^/opt/venv_torch/' | paste -sd ':' -)"
+  fi
+
+  # 2) 시스템 CUDA 후보 경로를 앞쪽에 추가
+  #    (이미 있으면 중복 없이 유지)
+  local candidates=(
+    "/usr/local/cuda/lib64"
+    "/usr/local/cuda/lib"
+    "/usr/lib/x86_64-linux-gnu"
+    "/usr/lib64"
+  )
+
+  local parts=()
+  for d in "${candidates[@]}"; do
+    [[ -d "$d" ]] && parts+=("$d")
+  done
+
+  local prefix=""
+  if [[ "${#parts[@]}" -gt 0 ]]; then
+    prefix="$(IFS=:; echo "${parts[*]}")"
+  fi
+
+  if [[ -n "$prefix" && -n "$cur" ]]; then
+    export LD_LIBRARY_PATH="${prefix}:${cur}"
+  elif [[ -n "$prefix" ]]; then
+    export LD_LIBRARY_PATH="${prefix}"
+  else
+    # 시스템 경로를 못 찾으면 cur만 유지 (그래도 unset은 안 함)
+    export LD_LIBRARY_PATH="${cur}"
+  fi
+
+  log "LD_LIBRARY_PATH(jax)=${LD_LIBRARY_PATH:-<empty>}"
+}
+
 sanity_torch() {
   log "sanity(torch): python=$("$(venv_python_torch)" -V 2>&1 | tr -d '\r')"
   if command -v nvidia-smi >/dev/null 2>&1; then
@@ -153,17 +199,27 @@ except Exception as e:
 PY
 }
 
-sanity_jax() {
+# ✅ JAX GPU 강제 체크 함수 (재발 방지)
+sanity_jax_and_must_gpu_if_requested() {
   log "sanity(jax): python=$("$(venv_python_jax)" -V 2>&1 | tr -d '\r')"
   "$(venv_python_jax)" - <<'PY'
+import os, sys
+want_gpu = os.environ.get("ENABLE_JAX_CUDA","0") == "1"
 try:
   import jax
   dev = jax.devices()
+  has_gpu = any(getattr(d, "platform", "") == "gpu" for d in dev)
   print("[sanity][jax] version:", jax.__version__)
   print("[sanity][jax] devices:", dev)
-  print("[sanity][jax] has_gpu:", any(getattr(d, "platform", "") == "gpu" for d in dev))
+  print("[sanity][jax] has_gpu:", has_gpu)
+  if want_gpu and not has_gpu:
+    raise SystemExit("[sanity][jax] ENABLE_JAX_CUDA=1 but has_gpu=False (CUDA jaxlib not active)")
+except SystemExit as e:
+  print(str(e))
+  raise
 except Exception as e:
   print("[sanity][jax] import/devices failed:", repr(e))
+  raise
 PY
 }
 
@@ -214,8 +270,6 @@ refresh_s3_mapping() {
 # Helper: ensure ./params symlink
 ########################################
 ensure_unified_params_link() {
-  # ColabDesign이 종종 ./params 를 찾으므로
-  # /workspace/unified/params -> /models/alphafold (AF_DIR) 링크를 보장
   local link_path="${APP_DIR}/params"
   if [[ -L "$link_path" || -e "$link_path" ]]; then
     rm -rf "$link_path" || true
@@ -310,8 +364,7 @@ cmd_install() {
     --index-url https://download.pytorch.org/whl/cu121 \
     torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0
 
-  # ✅ 중요: torch 2.2.0+cu121이 기대하는 cuDNN(=8.9.2.26)로 "재고정"
-  # - 이전에 9.x가 섞이면 libcudnn.so.8 링크가 없어져 ImportError가 날 수 있음
+  # ✅ cuDNN 재고정
   "$(venv_python_torch)" -m pip install -U --no-deps "nvidia-cudnn-cu12==8.9.2.26" || true
 
   "$(venv_python_torch)" -m pip install \
@@ -374,42 +427,40 @@ cmd_install() {
 
   "$(venv_python_jax)" -m pip install -U pip setuptools wheel
   "$(venv_python_jax)" -m pip install "numpy<2"
-  # ✅ 여기에 넣기 (가장 안전)
   "$(venv_python_jax)" -m pip install -U boto3 botocore
-  # ✅ alphafold_step / proteinmpnn_step가 pandas를 쓰므로 JAX_VENV에 설치
   "$(venv_python_jax)" -m pip install -U pandas
 
   ########################################
-  # ✅ ColabDesign install (ProteinMPNN / AlphaFold)
+  # ✅ ColabDesign install (JAX_VENV)
   ########################################
   if [[ ! -d "$COLABDESIGN_DIR" ]]; then
     log "Cloning ColabDesign into $COLABDESIGN_DIR"
     git clone https://github.com/sokrypton/ColabDesign.git "$COLABDESIGN_DIR"
   fi
 
-  # ColabDesign는 JAX/Tensor 관련 deps를 건드릴 수 있어서 JAX venv에 설치
   log "installing ColabDesign (editable) (JAX_VENV)"
   "$(venv_python_jax)" -m pip install -e "$COLABDESIGN_DIR"
 
-  # (옵션) JAX CUDA 설치 시도 (best-effort)
+  ########################################
+  # ✅ JAX CUDA: 재발 방지 설치 로직
+  ########################################
   if [[ "$ENABLE_JAX_CUDA" == "1" ]]; then
-    log "trying to install CUDA-enabled jaxlib (best-effort; may fail depending on CUDA/driver) (JAX_VENV)"
-    "$(venv_python_jax)" -m pip install -U "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || true
+    log "JAX CUDA REQUIRED: removing CPU jax/jaxlib then installing CUDA-enabled jaxlib (JAX_VENV)"
+    # 1) 먼저 기존 jax/jaxlib 제거 (CPU 잔재가 남으면 계속 CPU로 뜨는 케이스 방지)
+    "$(venv_python_jax)" -m pip uninstall -y jax jaxlib || true
+
+    # 2) CUDA jax 설치 (실패하면 바로 죽어야 재발 방지 됨)
+    #    (여기서 || true 절대 금지)
+    "$(venv_python_jax)" -m pip install -U "jax[cuda12]" -f "$JAX_CUDA_WHEEL_INDEX"
+
   else
-    # CPU jax 기본 확보
+    log "JAX CPU allowed: installing CPU jax (JAX_VENV)"
     "$(venv_python_jax)" -m pip install -U "jax" || true
   fi
 
   log "sanity check (TORCH_VENV)"
-  "$(venv_python_torch)" - <<'PY'
-import sys
-print("python:", sys.version.split()[0])
-try:
-  import torch
-  print("torch:", torch.__version__, "cuda:", torch.version.cuda, "avail:", torch.cuda.is_available())
-except Exception as e:
-  print("torch import failed:", e)
-PY
+  set_ld_library_path_for_torch
+  sanity_torch
 
   # ✅ cudnn .so 존재 체크 (python 버전 하드코딩 제거)
   TORCH_SP="$(torch_site_packages || true)"
@@ -426,30 +477,10 @@ PY
   fi
 
   log "sanity check (JAX_VENV)"
-  "$(venv_python_jax)" - <<'PY'
-import sys
-print("python:", sys.version.split()[0])
-try:
-  import pandas as pd
-  print("pandas:", pd.__version__)
-except Exception as e:
-  print("pandas import failed:", e)
-
-try:
-  import colabdesign
-  print("colabdesign import: OK")
-except Exception as e:
-  print("colabdesign import failed:", e)
-
-try:
-  import jax
-  print("jax:", jax.__version__)
-  dev = jax.devices()
-  print("jax devices:", dev)
-  print("has_gpu:", any(getattr(d, "platform", "") == "gpu" for d in dev))
-except Exception as e:
-  print("jax import/devices failed:", e)
-PY
+  # ✅ JAX 쪽은 시스템 CUDA 경로를 유지/추가한 상태로 체크
+  set_ld_library_path_for_jax
+  export ENABLE_JAX_CUDA
+  sanity_jax_and_must_gpu_if_requested
 
   log "install done"
 }
@@ -621,30 +652,26 @@ cmd_run() {
   cmd_download_params
   ensure_unified_params_link
 
-  # ✅ step별 PYTHONPATH 분리 (재발 방지 핵심)
-  # 기본은 src만
+  # ✅ step별 PYTHONPATH 분리 (재발 방지)
   export PYTHONPATH="$SCRIPT_DIR/src:${PYTHONPATH:-}"
 
-  # ✅ 핵심: step별 python 선택 + LD_LIBRARY_PATH 처리
   local py
   if [[ "$step" == "alphafold" || "$step" == "proteinMPNN" ]]; then
     py="$(venv_python_jax)"
 
-    # jax/af step은 torch nvidia libs로 꼬이는 케이스가 있어서 방어
-    unset LD_LIBRARY_PATH || true
+    # ✅ torch venv nvidia libs는 제거, 시스템 CUDA 경로는 유지/추가
+    set_ld_library_path_for_jax
+    export ENABLE_JAX_CUDA
     log "Using JAX_VENV python: $py"
-    log "LD_LIBRARY_PATH unset for step=$step (jax/af safety)"
     log "PYTHONPATH(jax)=$PYTHONPATH"
 
-    # 실행 전 sanity (로그로 증거 남김)
-    sanity_jax
-    if [[ "${ENABLE_JAX_CUDA:-0}" == "1" ]]; then
-      warn "ENABLE_JAX_CUDA=1 (requested). Check has_gpu in sanity log above."
-    fi
+    # ✅ 실행 전 반드시 체크 (ENABLE_JAX_CUDA=1이면 GPU 아니면 여기서 바로 죽음)
+    sanity_jax_and_must_gpu_if_requested
+
   else
     py="$(venv_python_torch)"
 
-    # torch step은 nvidia libs path 세팅 (python 버전 하드코딩 제거)
+    # torch step은 nvidia libs path 세팅
     set_ld_library_path_for_torch
     log "Using TORCH_VENV python: $py"
     log "LD_LIBRARY_PATH set (torch/rfdiffusion)"
@@ -653,7 +680,6 @@ cmd_run() {
     export PYTHONPATH="$SCRIPT_DIR/src:$RFDIFFUSION_DIR:${PYTHONPATH:-}"
     log "PYTHONPATH(torch)=$PYTHONPATH"
 
-    # 실행 전 sanity (로그로 증거 남김)
     sanity_torch
   fi
 
@@ -686,7 +712,6 @@ cmd_serve() {
   ensure_dir "$APP_DIR"
   ensure_dir "$OUTPUTS_DIR"
 
-  # API 서버는 torch venv 기반
   "$(venv_python_torch)" -c "import uvicorn, fastapi" >/dev/null 2>&1 || \
     "$(venv_python_torch)" -m pip install -U uvicorn fastapi
 
@@ -708,6 +733,7 @@ cmd_serve() {
   env_kv+=("MODELS_DIR=$MODELS_DIR")
   env_kv+=("AF_DIR=$AF_DIR")
   env_kv+=("COLABDESIGN_DIR=$COLABDESIGN_DIR")
+  env_kv+=("ENABLE_JAX_CUDA=$ENABLE_JAX_CUDA")
 
   add_env_if_nonempty env_kv "S3_BUCKET" "${S3_BUCKET:-}"
   add_env_if_nonempty env_kv "S3_BASE" "${S3_BASE:-}"
@@ -783,6 +809,7 @@ AlphaFold/ColabDesign:
   AF_DIR=/models/alphafold
   COLABDESIGN_DIR=/workspace/colabdesign
   ENABLE_JAX_CUDA=0|1
+  JAX_CUDA_WHEEL_INDEX=$JAX_CUDA_WHEEL_INDEX
 
 S3 upload env (optional):
   S3_BUCKET=my-bucket


### PR DESCRIPTION
[핵심 내용]
- Torch와 JAX를 같은 CUDA 환경에서 동시에 사용하면서 발생하던 충돌 문제 해결
- venv + LD_LIBRARY_PATH 를 step 단위로 완전히 격리하였습니다.
- RTX 4090 기준:
   - RFdiffusion → PyTorch GPU 정상
   - ProteinMPNN / AlphaFold → JAX GPU 정상
=> 모든 시뮬레이션 툴에서 GPU 사용이 가능합니다.
- 시뮬레이션 툴(RFdiffusion, ProteinMPNN, AlphaFold)을 직접 쉘 실행이 아닌 API 서버 기반(curl) 으로 통합 실행하도록 정리
- RunPod 연동 환경변수를 Simulation 전용으로 분리
   - RUNPOD_BASE_URL → RUNPOD_SIMS_BASE_URL
   - RUNPOD_API_KEY → RUNPOD_SIMS_API_KEY

[수정 사항]
1. Torch / JAX 가상환경 완전 분리
- RFdiffusion → TORCH_VENV (PyTorch + CUDA)
- ProteinMPNN, AlphaFold → JAX_VENV (JAX CUDA plugin)
각 시뮬레이션 툴마다 서로 다른 가상환경을 사용하게 하여 Torch 버전 충돌나던 문제를 해결하였습니다.
2. step 기반 LD_LIBRARY_PATH 동적 설정
- CUDA / cuDNN / cuSPARSE 충돌의 원인이었던 공용 LD_LIBRARY_PATH 사용을 제거하였습니다.
- 실행 step에 따라 필요한 CUDA 라이브러리만 주입
```text
rfdiffusion  → torch CUDA 라이브러리
proteinMPNN → jax CUDA 라이브러리
alphafold   → jax CUDA 라이브러리
```
3. GPU sanity check 로직 강화
- 각 스탭 실행 전

   - Torch: torch.cuda.is_available(), GPU 이름 출력

   - JAX: jax.devices() 확인

=> GPU 비활성 시 즉시 로그로 확인 가능

4. API 서버 기반 실행 흐름 고정 (curl 중심)
- 시뮬레이션 실행은 항상 API 서버(/run)를 통해서만 수행
예시
```bash
curl
 → FastAPI (api_server.py)
/run
 → unified_shell_script.sh
 → rfdiffusion / proteinMPNN / alphafold
 → outputs + logs + S3 업로드
```

5. RunPod Simulation 전용 환경변수로 분리
- 변경 전 환경변수
```env
RUNPOD_BASE_URL=...
RUNPOD_API_KEY=...
```
- 변경 후 환경변수
```env
RUNPOD_SIMS_BASE_URL=...
RUNPOD_SIMS_API_KEY=...
```
6. views_runpod.py 수정
- 참조 키 변경
  - RUNPOD_BASE_URL → RUNPOD_SIMS_BASE_URL
  - RUNPOD_API_KEY → RUNPOD_SIMS_API_KEY
- Health check / run 요청 모두 Simulation 전용 URL만 사용

[실행 절차]
- 런팟 생성
- 런팟 환경변수 적용
```bash
cat >/etc/profile.d/aws_s3_env.sh <<'EOF'
# Load AWS_/S3_ vars from PID 1 into shells (RunPod secrets often live only in PID1 environ)
# Safe to source multiple times.

if [[ -r /proc/1/environ ]]; then
  while IFS= read -r line; do
    case "$line" in
      AWS_*|S3_*)
        export "$line"
        ;;
    esac
  done < <(tr '\0' '\n' </proc/1/environ 2>/dev/null)
fi
EOF

chmod 0644 /etc/profile.d/aws_s3_env.sh
```
```bash
source /etc/profile.d/aws_s3_env.sh
printenv | egrep '^(AWS_|S3_)'
```
- scp를 통해 로컬 코드를 런팟으로 전송
- 설치
```bash
cd /workspace/unified
export ENABLE_JAX_CUDA=1
chmod +x unified_shell_script.sh
./unified_shell_script.sh install
```
- API 서버 실행
```bash
cd /workspace/unified

export ENABLE_JAX_CUDA=1
unset API_KEY   # 인증 사용 안 하는 경우

/opt/venv_torch/bin/uvicorn api_server:app \
  --host 0.0.0.0 \
  --port 8000
```
```bash
curl -s http://127.0.0.1:8000/health
```
- RFdiffusion 실행 (Torch GPU)
```bash
curl -s -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{
    "experiment_id": "t_rfd_001",
    "step": "rfdiffusion",
    "mode": "backbone",
    "contigs": "100",
    "iterations": 1,
    "s3_upload_logs": true
  }'
```
```bash
tail -f /workspace/unified/outputs/_logs/t_rfd_001.log
```
- ProteinMPNN 실행 (JAX GPU)
```bash
curl -s -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{
    "experiment_id": "t_rfd_001",
    "step": "proteinMPNN",
    "mode": "backbone",
    "contigs": "100",
    "iterations": 1,
    "s3_upload_logs": true
  }'
```
```bash
tail -f /workspace/unified/outputs/_logs/t_rfd_001.log
```
- AlphaFold 실행 (JAX GPU)
```bash
curl -s -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{
    "experiment_id": "t_rfd_001",
    "step": "alphafold",
    "mode": "backbone",
    "contigs": "100",
    "iterations": 1,
    "s3_upload_logs": true
  }'
```
```bash
tail -f /workspace/unified/outputs/_logs/t_rfd_001.log
```
- 결과물 확인
```bash
ls -lah /workspace/unified/outputs | grep t_rfd_001
```

[결과 사진]
<img width="1290" height="539" alt="스크린샷 2026-01-05 16 43 52" src="https://github.com/user-attachments/assets/fb7a2a1b-3cb3-4dd7-8732-7ccf37c80f8d" />
-> 실행결과 확인

<img width="1299" height="410" alt="스크린샷 2026-01-05 16 45 33" src="https://github.com/user-attachments/assets/8791a4a6-0a2e-45e6-9aec-8ed34f237f21" />
-> AlphaFold 실행 간 GPU 사용 증거
<img width="1293" height="492" alt="스크린샷 2026-01-05 16 45 49" src="https://github.com/user-attachments/assets/d52c5b18-90e1-47bf-a001-8af1608d62ac" />
-> proteinMPNN 실행 간 GPU 사용 증거

<img width="1512" height="631" alt="스크린샷 2026-01-05 16 55 15" src="https://github.com/user-attachments/assets/4ae6662e-2583-419a-bfa0-a9ddbe496238" />
<img width="1512" height="673" alt="스크린샷 2026-01-05 16 55 19" src="https://github.com/user-attachments/assets/b2516d79-49f4-48ea-9fab-b5b002a8becc" />
<img width="1512" height="642" alt="스크린샷 2026-01-05 16 55 22" src="https://github.com/user-attachments/assets/b169b8a3-4c1b-4885-b553-367b8ac2a7ee" />
<img width="1512" height="585" alt="스크린샷 2026-01-05 16 55 11" src="https://github.com/user-attachments/assets/64c12d9d-c368-48e2-ac39-5ca2d65543f4" />
-> AWS S3 업로드 결과
